### PR TITLE
Stop rejecting tx on component unmount

### DIFF
--- a/examples/vite/main.tsx
+++ b/examples/vite/main.tsx
@@ -1,10 +1,13 @@
+import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import "./index.css"
 import Providers from "./src/Providers"
 import App from "./src/App"
 
 createRoot(document.getElementById("root")!).render(
-  <Providers>
-    <App />
-  </Providers>,
+  <StrictMode>
+    <Providers>
+      <App />
+    </Providers>
+  </StrictMode>,
 )

--- a/packages/interwovenkit-react/src/components/Modal.tsx
+++ b/packages/interwovenkit-react/src/components/Modal.tsx
@@ -13,10 +13,9 @@ interface Props {
   trigger?: ReactNode
   open: boolean
   onOpenChange: (open: boolean) => void
-  onInteractOutside?: () => void
 }
 
-const Modal = ({ title, children, trigger, open, onOpenChange, onInteractOutside }: Props) => {
+const Modal = ({ title, children, trigger, open, onOpenChange }: Props) => {
   const fullscreen = useContext(fullscreenContext)
 
   return (
@@ -27,10 +26,7 @@ const Modal = ({ title, children, trigger, open, onOpenChange, onInteractOutside
         {/* Overlay is not used because it breaks scrolling behavior in production */}
         <div className={clsx(styles.overlay, { [styles.fullscreen]: fullscreen })} />
 
-        <Dialog.Content
-          className={clsx(styles.content, { [styles.fullscreen]: fullscreen })}
-          onInteractOutside={onInteractOutside}
-        >
+        <Dialog.Content className={clsx(styles.content, { [styles.fullscreen]: fullscreen })}>
           {title && (
             <header className={styles.header}>
               <Dialog.Title className={styles.title}>{title}</Dialog.Title>

--- a/packages/interwovenkit-react/src/components/Modal.tsx
+++ b/packages/interwovenkit-react/src/components/Modal.tsx
@@ -13,9 +13,10 @@ interface Props {
   trigger?: ReactNode
   open: boolean
   onOpenChange: (open: boolean) => void
+  onInteractOutside?: () => void
 }
 
-const Modal = ({ title, children, trigger, open, onOpenChange }: Props) => {
+const Modal = ({ title, children, trigger, open, onOpenChange, onInteractOutside }: Props) => {
   const fullscreen = useContext(fullscreenContext)
 
   return (
@@ -26,7 +27,10 @@ const Modal = ({ title, children, trigger, open, onOpenChange }: Props) => {
         {/* Overlay is not used because it breaks scrolling behavior in production */}
         <div className={clsx(styles.overlay, { [styles.fullscreen]: fullscreen })} />
 
-        <Dialog.Content className={clsx(styles.content, { [styles.fullscreen]: fullscreen })}>
+        <Dialog.Content
+          className={clsx(styles.content, { [styles.fullscreen]: fullscreen })}
+          onInteractOutside={onInteractOutside}
+        >
           {title && (
             <header className={styles.header}>
               <Dialog.Title className={styles.title}>{title}</Dialog.Title>

--- a/packages/interwovenkit-react/src/pages/tx/TxRequest.tsx
+++ b/packages/interwovenkit-react/src/pages/tx/TxRequest.tsx
@@ -4,7 +4,7 @@ import BigNumber from "bignumber.js"
 import { sentenceCase } from "change-case"
 import type { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin"
 import { calculateFee, GasPrice } from "@cosmjs/stargate"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query"
 import { useInitiaAddress } from "@/public/data/hooks"
 import { DEFAULT_GAS_PRICE_MULTIPLIER } from "@/public/data/constants"
@@ -103,12 +103,6 @@ const TxRequest = () => {
       reject(new Error(await normalizeError(error)))
     },
   })
-
-  useEffect(() => {
-    return () => {
-      reject(new Error("User rejected"))
-    }
-  }, [reject])
 
   const isInsufficient = !canPayFee(feeDenom)
 

--- a/packages/interwovenkit-react/src/public/app/Drawer.tsx
+++ b/packages/interwovenkit-react/src/public/app/Drawer.tsx
@@ -1,12 +1,14 @@
 import clsx from "clsx"
+import { useAtomValue } from "jotai"
 import { useContext, useLayoutEffect, type PropsWithChildren } from "react"
 import { createPortal } from "react-dom"
 import { useMedia } from "react-use"
 import type { FallbackProps } from "react-error-boundary"
 import { useTransition, animated } from "@react-spring/web"
-import { useQueryClient } from "@tanstack/react-query"
+import { useIsMutating, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@/lib/router"
 import { useDrawer } from "@/data/ui"
+import { TX_APPROVAL_MUTATION_KEY, txRequestHandlerAtom } from "@/data/tx"
 import AsyncBoundary from "@/components/AsyncBoundary"
 import Scrollable from "@/components/Scrollable"
 import Status from "@/components/Status"
@@ -25,6 +27,22 @@ const Drawer = ({ children }: PropsWithChildren) => {
 
   // Lock body scroll when the drawer is open on small screens
   useLockBodyScroll(isDrawerOpen && isSmall)
+
+  // FIXME: React StrictMode causes a problem by unmounting the component once on purpose.
+  // Should reject on unmount, but didn't work as expected.
+  // Currently handled via drawer/modal close instead.
+  // Would be nice to fix this properly later.
+  const txRequest = useAtomValue(txRequestHandlerAtom)
+  const isPendingTransaction = useIsMutating({ mutationKey: [TX_APPROVAL_MUTATION_KEY] })
+  const handleOverlayClick = () => {
+    const errorMessage = isPendingTransaction
+      ? "User exited before response arrived. Transaction may succeed or fail."
+      : "User rejected"
+    // The drawer must be closed first.
+    // This is because `reject` may re-throw the error after handling it.
+    closeDrawer()
+    txRequest?.reject(new Error(errorMessage))
+  }
 
   // Error
   const navigate = useNavigate()
@@ -60,7 +78,7 @@ const Drawer = ({ children }: PropsWithChildren) => {
     <>
       {drawerTransition((style, item) =>
         item ? (
-          <animated.button style={style} className={styles.overlay} onClick={closeDrawer}>
+          <animated.button style={style} className={styles.overlay} onClick={handleOverlayClick}>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14" height="14">
               <path d="M7.168 14.04 l 6.028 -6.028 l -6.028 -6.028 L8.57 .582 L16 8.012 l -7.43 7.43 l -1.402 -1.402 Z" />
               <path d="M0.028 14.04 l 6.028 -6.028 L0.028 1.984 L1.43 .582 l 7.43 7.43 l -7.43 7.43 L0.028 14.04 Z" />

--- a/packages/interwovenkit-react/src/public/app/ModalProvider.tsx
+++ b/packages/interwovenkit-react/src/public/app/ModalProvider.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useState, type PropsWithChildren } from "react"
+import { useAtomValue } from "jotai"
 import Modal from "@/components/Modal"
 import TxRequest from "@/pages/tx/TxRequest"
+import { txRequestHandlerAtom } from "@/data/tx"
 import type { ModalOptions } from "./ModalContext"
 import { ModalContext } from "./ModalContext"
 
 const ModalProvider = ({ children }: PropsWithChildren) => {
   const [{ title, content, path }, setOptions] = useState<ModalOptions>({})
   const [isOpen, setIsOpen] = useState(false)
+  const txRequest = useAtomValue(txRequestHandlerAtom)
 
   const openModal = useCallback((options: ModalOptions) => {
     setOptions(options)
@@ -22,7 +25,16 @@ const ModalProvider = ({ children }: PropsWithChildren) => {
     <ModalContext.Provider value={{ openModal, closeModal }}>
       {children}
 
-      <Modal title={title} open={isOpen} onOpenChange={setIsOpen}>
+      <Modal
+        title={title}
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        // FIXME: React StrictMode causes a problem by unmounting the component once on purpose.
+        // Should reject on unmount, but didn't work as expected.
+        // Currently handled via drawer/modal close instead.
+        // Would be nice to fix this properly later.
+        onInteractOutside={() => txRequest?.reject(new Error("User rejected"))}
+      >
         {path === "/tx" ? <TxRequest /> : content}
       </Modal>
     </ModalContext.Provider>

--- a/packages/interwovenkit-react/src/public/app/ModalProvider.tsx
+++ b/packages/interwovenkit-react/src/public/app/ModalProvider.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useState, type PropsWithChildren } from "react"
 import { useAtomValue } from "jotai"
+import { txRequestHandlerAtom } from "@/data/tx"
 import Modal from "@/components/Modal"
 import TxRequest from "@/pages/tx/TxRequest"
-import { txRequestHandlerAtom } from "@/data/tx"
 import type { ModalOptions } from "./ModalContext"
 import { ModalContext } from "./ModalContext"
 

--- a/packages/interwovenkit-react/src/public/app/ModalProvider.tsx
+++ b/packages/interwovenkit-react/src/public/app/ModalProvider.tsx
@@ -21,6 +21,17 @@ const ModalProvider = ({ children }: PropsWithChildren) => {
     setIsOpen(false)
   }, [])
 
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        txRequest?.reject(new Error("User rejected"))
+        setOptions({})
+      }
+      setIsOpen(open)
+    },
+    [txRequest],
+  )
+
   return (
     <ModalContext.Provider value={{ openModal, closeModal }}>
       {children}
@@ -28,12 +39,11 @@ const ModalProvider = ({ children }: PropsWithChildren) => {
       <Modal
         title={title}
         open={isOpen}
-        onOpenChange={setIsOpen}
         // FIXME: React StrictMode causes a problem by unmounting the component once on purpose.
         // Should reject on unmount, but didn't work as expected.
         // Currently handled via drawer/modal close instead.
         // Would be nice to fix this properly later.
-        onInteractOutside={() => txRequest?.reject(new Error("User rejected"))}
+        onOpenChange={handleOpenChange}
       >
         {path === "/tx" ? <TxRequest /> : content}
       </Modal>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transaction rejection when drawers or modals are closed, ensuring users receive accurate error messages if they exit before a response or manually reject a transaction.
  * Addressed issues related to React StrictMode by moving rejection logic from component unmount to drawer or modal close actions for more reliable user experience.
* **Chores**
  * Enabled React StrictMode in the app to enhance development checks and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->