### PR TITLE
Update op withdrawals list design

### DIFF
--- a/packages/interwovenkit-react/src/pages/bridge/op/ClaimButton.module.css
+++ b/packages/interwovenkit-react/src/pages/bridge/op/ClaimButton.module.css
@@ -1,15 +1,15 @@
 .button {
   border-radius: calc(infinity * 1px);
-  border: 1px solid var(--gray-6);
+  border: 1px solid var(--gray-3);
+  color: var(--gray-1);
   font-size: 12px;
   font-weight: 600;
-  height: 38px;
-  padding: 0 24px;
+  padding: 6px 24px;
 
   transition: border-color var(--transition) ease;
 
   &:hover {
-    border-color: var(--gray-0);
+    background-color: var(--gray-8);
   }
 }
 

--- a/packages/interwovenkit-react/src/pages/bridge/op/ClaimButton.module.css
+++ b/packages/interwovenkit-react/src/pages/bridge/op/ClaimButton.module.css
@@ -6,7 +6,7 @@
   font-weight: 600;
   padding: 6px 24px;
 
-  transition: border-color var(--transition) ease;
+  transition: background-color var(--transition) ease;
 
   &:hover {
     background-color: var(--gray-8);

--- a/packages/interwovenkit-react/src/pages/bridge/op/ClaimButton.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/op/ClaimButton.tsx
@@ -70,7 +70,7 @@ const ClaimButton = () => {
     return (
       <div className={styles.claimed}>
         <IconCheckCircleFilled size={14} />
-        <span>Success</span>
+        <span>Claimed</span>
       </div>
     )
   }

--- a/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalAction.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalAction.tsx
@@ -1,7 +1,7 @@
 import { isFuture } from "date-fns"
 import WithIsSubmitted from "./WithIsSubmitted"
 import WithdrawalSubmitted from "./WithdrawalSubmitted"
-import WithdrawalCountdown from "./WithdrawalCountDown"
+import WithdrawalCountdown from "./WithdrawalCountdown"
 import WithClaimableDate from "./WithClaimableDate"
 import WithUpdateReminder from "./WithUpdateReminder"
 import ClaimButton from "./ClaimButton"

--- a/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalAsset.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalAsset.tsx
@@ -14,7 +14,7 @@ const WithdrawalAsset = ({ amount, denom }: Coin) => {
     <div className={styles.asset}>
       <Image src={logoUrl} width={32} height={32} />
       <div className={styles.info}>
-        <span>{formatAmount(amount, { decimals })}</span>
+        <span className="monospace">{formatAmount(amount, { decimals })}</span>
         <span className={styles.symbol}>{symbol}</span>
       </div>
     </div>

--- a/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalCountDown.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalCountDown.tsx
@@ -1,19 +1,11 @@
-import { IconInfoFilled } from "@initia/icons-react"
-import WidgetTooltip from "@/components/WidgetTooltip"
 import Countdown from "./Countdown"
 import styles from "./WithdrawalCountdown.module.css"
-
-const DESCRIPTION = "Time remaining before you can claim"
 
 const WithdrawalCountdown = ({ date }: { date: Date }) => {
   return (
     <div className={styles.container}>
+      <span className={styles.title}>Claimable in</span>
       <Countdown date={date} />
-      <WidgetTooltip label={DESCRIPTION}>
-        <span className={styles.icon}>
-          <IconInfoFilled size={12} />
-        </span>
-      </WidgetTooltip>
     </div>
   )
 }

--- a/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalCountdown.module.css
+++ b/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalCountdown.module.css
@@ -1,7 +1,5 @@
 .container {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  text-align: right;
 }
 
 .title {

--- a/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalCountdown.module.css
+++ b/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalCountdown.module.css
@@ -1,9 +1,10 @@
 .container {
   display: flex;
-  align-items: center;
-  gap: 4px;
+  flex-direction: column;
+  align-items: flex-end;
 }
 
-.icon {
-  color: var(--gray-2);
+.title {
+  color: var(--gray-3);
+  font-size: 11px;
 }

--- a/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalCountdown.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalCountdown.tsx
@@ -4,7 +4,7 @@ import styles from "./WithdrawalCountdown.module.css"
 const WithdrawalCountdown = ({ date }: { date: Date }) => {
   return (
     <div className={styles.container}>
-      <span className={styles.title}>Claimable in</span>
+      <div className={styles.title}>Claimable in</div>
       <Countdown date={date} />
     </div>
   )

--- a/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalSubmitted.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/op/WithdrawalSubmitted.tsx
@@ -2,13 +2,12 @@ import { IconInfoFilled } from "@initia/icons-react"
 import WidgetTooltip from "@/components/WidgetTooltip"
 import styles from "./WithdrawalSubmitted.module.css"
 
-const DESCRIPTION =
-  "Your withdrawal request is being processed, and time remaining will show up once it is in queue."
+const DESCRIPTION = "Withdrawal will begin within an hour"
 
 const WithdrawalSubmitted = () => {
   return (
     <div className={styles.container}>
-      <span>Withdrawal submitted</span>
+      <span>In progress</span>
       <WidgetTooltip label={DESCRIPTION}>
         <span className={styles.icon}>
           <IconInfoFilled size={12} />


### PR DESCRIPTION
Missing opacity/color changes for withdrawals with claimed status, pending [design discussion](https://linear.app/initia-labs/issue/FE-1468/improve-the-list-info-on-withdrawal-status#comment-4b4eb886).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated button and countdown component styles for improved appearance, including changes to border color, padding, font, and layout.
  * Amounts in withdrawal assets now use a monospace font for better readability.

* **New Features**
  * Countdown component now displays a static "Claimable in" label instead of a tooltip and icon.

* **Bug Fixes**
  * Updated user-facing text for claimed withdrawals from "Success" to "Claimed."
  * Changed withdrawal status text from "Withdrawal submitted" to "In progress" with a clearer, shorter description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->