### PR TITLE
fix: improve max send amount calculation with fee token selection

### DIFF
--- a/packages/interwovenkit-react/src/components/form/BalanceButton.module.css
+++ b/packages/interwovenkit-react/src/components/form/BalanceButton.module.css
@@ -23,5 +23,6 @@
 
   &:disabled {
     color: var(--dimmed);
+    cursor: not-allowed;
   }
 }

--- a/packages/interwovenkit-react/src/components/form/BalanceButton.module.css
+++ b/packages/interwovenkit-react/src/components/form/BalanceButton.module.css
@@ -20,4 +20,8 @@
   &:hover {
     color: var(--gray-0);
   }
+
+  &:disabled {
+    color: var(--dimmed);
+  }
 }

--- a/packages/interwovenkit-react/src/components/form/BalanceButton.tsx
+++ b/packages/interwovenkit-react/src/components/form/BalanceButton.tsx
@@ -2,12 +2,17 @@ import type { PropsWithChildren } from "react"
 import { IconWallet } from "@initia/icons-react"
 import styles from "./BalanceButton.module.css"
 
-const BalanceButton = ({ onClick, children }: PropsWithChildren<{ onClick: () => void }>) => {
+interface Props {
+  onClick: () => void
+  disabled?: boolean
+}
+
+const BalanceButton = ({ onClick, children, disabled }: PropsWithChildren<Props>) => {
   return (
     <div className={styles.wrapper}>
       <IconWallet size={16} />
       <span className={styles.balance}>{children}</span>
-      <button type="button" className={styles.button} onClick={() => onClick()}>
+      <button type="button" className={styles.button} onClick={() => onClick()} disabled={disabled}>
         MAX
       </button>
     </div>

--- a/packages/interwovenkit-react/src/pages/bridge/SelectRouteOption.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/SelectRouteOption.tsx
@@ -48,12 +48,12 @@ const SelectRouteOption = ({ label, query, value, onSelect, checked }: Props) =>
       <div className={styles.amount}>
         {isLoading ? (
           <Loader size={14} />
-        ) : (
+        ) : data ? (
           <>
-            <span>{formatAmount(data?.amount_out, { decimals: dstAsset.decimals })}</span>
+            <span>{formatAmount(data.amount_out, { decimals: dstAsset.decimals })}</span>
             <span className={styles.symbol}>{dstAsset.symbol}</span>
           </>
-        )}
+        ) : null}
       </div>
     </button>
   )

--- a/packages/interwovenkit-react/src/pages/bridge/data/tx.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/tx.ts
@@ -7,7 +7,7 @@ import { createElement, Fragment } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import type { StatusResponseJson, TrackResponseJson, TxJson } from "@skip-go/client"
 import { aminoConverters, aminoTypes } from "@initia/amino-converter"
-import { InitiaAddress } from "@initia/utils"
+import { InitiaAddress, toBaseUnit } from "@initia/utils"
 import { Link, useLocationState, useNavigate } from "@/lib/router"
 import { DEFAULT_GAS_ADJUSTMENT } from "@/public/data/constants"
 import { useNotification } from "@/public/app/NotificationContext"
@@ -91,7 +91,14 @@ export function useBridgeTx(tx: TxJson) {
           })
 
           if (srcChainType === "initia") {
-            const txHash = await requestTxSync({ messages, chainId: srcChainId, internal: 1 })
+            const { srcDenom, quantity } = values
+            const { decimals } = findAsset(srcDenom)
+            const txHash = await requestTxSync({
+              messages,
+              chainId: srcChainId,
+              internal: 1,
+              spendCoins: [{ denom: srcDenom, amount: toBaseUnit(quantity, { decimals }) }],
+            })
             const wait = waitForTxConfirmation({ txHash, chainId: srcChainId })
             return { txHash, wait }
           }

--- a/packages/interwovenkit-react/src/pages/wallet/txs/send/SendFields.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/txs/send/SendFields.tsx
@@ -116,7 +116,7 @@ export const SendFields = () => {
                     shouldValidate: true,
                   })
                 }
-                disabled={isLoading}
+                disabled={gasPrices.some(({ denom: feeDenom }) => feeDenom === denom) && isLoading}
               >
                 {formatAmount(balance ?? "0", { decimals })}
               </BalanceButton>

--- a/packages/interwovenkit-react/src/pages/wallet/txs/send/SendFields.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/txs/send/SendFields.tsx
@@ -7,6 +7,7 @@ import { useChain, useManageChains, usePricesQuery } from "@/data/chains"
 import { InitiaAddress, formatAmount, formatNumber, toBaseUnit, fromBaseUnit } from "@initia/utils"
 import { DEFAULT_GAS_ADJUSTMENT } from "@/public/data/constants"
 import { useInterwovenKit } from "@/public/data/hooks"
+import { STALE_TIMES } from "@/data/http"
 import { useAsset } from "@/data/assets"
 import { useBalances } from "@/data/account"
 import { useGasPrices, useLastFeeDenom } from "@/data/fee"
@@ -47,7 +48,7 @@ export const SendFields = () => {
   const balance = balances.find((coin) => coin.denom === denom)?.amount ?? "0"
   const price = prices?.find(({ id }) => id === denom)?.price
 
-  const { data: estimatedGas = 0, isLoading } = useQuery({
+  const { data: estimatedGas = 200000, isLoading } = useQuery({
     queryKey: queryKeys.gas({ chainId, denom, initiaAddress }).queryKey,
     queryFn: () => {
       const messages = [
@@ -62,6 +63,7 @@ export const SendFields = () => {
       ]
       return estimateGas({ messages, chainId })
     },
+    staleTime: STALE_TIMES.INFINITY,
   })
 
   const gas = Math.ceil(estimatedGas * DEFAULT_GAS_ADJUSTMENT)

--- a/packages/interwovenkit-react/src/pages/wallet/txs/send/max.test.ts
+++ b/packages/interwovenkit-react/src/pages/wallet/txs/send/max.test.ts
@@ -1,142 +1,124 @@
 import { toBaseUnit } from "@initia/utils"
 import { calcMaxAmount } from "./max"
 
-describe("getMaxAmount", () => {
+describe("calcMaxAmount", () => {
   const gasPrices = [
     { denom: "INIT", amount: "0.015" },
     { denom: "USDC", amount: "0.03" },
   ]
 
-  const gas = 200000
+  const gas = Math.floor(1e6 / 0.015)
 
-  it("should deduct fee from same token balance when lastFeeDenom equals denom", () => {
+  describe("Balance 0.01 INIT + 0.01 USDC", () => {
+    const balances = [
+      { denom: "INIT", amount: String(0.01 * 1e6) },
+      { denom: "USDC", amount: String(0.01 * 1e6) },
+    ]
+
+    test.each`
+      denom     | lastFeeDenom | expected
+      ${"INIT"} | ${null}      | ${toBaseUnit("0", { decimals: 6 })}
+      ${"INIT"} | ${"INIT"}    | ${toBaseUnit("0", { decimals: 6 })}
+      ${"INIT"} | ${"USDC"}    | ${toBaseUnit("0", { decimals: 6 })}
+      ${"USDC"} | ${null}      | ${toBaseUnit("0", { decimals: 6 })}
+      ${"USDC"} | ${"INIT"}    | ${toBaseUnit("0", { decimals: 6 })}
+      ${"USDC"} | ${"USDC"}    | ${toBaseUnit("0", { decimals: 6 })}
+    `(
+      "returns $expected when sending $denom with lastFeeDenom=$lastFeeDenom",
+      ({ denom, lastFeeDenom, expected }) => {
+        const result = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
+        expect(result).toBe(expected)
+      },
+    )
+  })
+
+  describe("Balance 0.01 INIT + 100 USDC", () => {
+    const balances = [
+      { denom: "INIT", amount: String(0.01 * 1e6) },
+      { denom: "USDC", amount: String(100 * 1e6) },
+    ]
+
+    test.each`
+      denom     | lastFeeDenom | expected
+      ${"INIT"} | ${null}      | ${toBaseUnit("0.01", { decimals: 6 })}
+      ${"INIT"} | ${"INIT"}    | ${toBaseUnit("0.01", { decimals: 6 })}
+      ${"INIT"} | ${"USDC"}    | ${toBaseUnit("0.01", { decimals: 6 })}
+      ${"USDC"} | ${null}      | ${toBaseUnit("98", { decimals: 6 })}
+      ${"USDC"} | ${"INIT"}    | ${toBaseUnit("98", { decimals: 6 })}
+      ${"USDC"} | ${"USDC"}    | ${toBaseUnit("98", { decimals: 6 })}
+    `(
+      "returns $expected when sending $denom with lastFeeDenom=$lastFeeDenom",
+      ({ denom, lastFeeDenom, expected }) => {
+        const result = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
+        expect(result).toBe(expected)
+      },
+    )
+  })
+
+  describe("Balance 100 INIT + 0.01 USDC", () => {
+    const balances = [
+      { denom: "INIT", amount: String(100 * 1e6) },
+      { denom: "USDC", amount: String(0.01 * 1e6) },
+    ]
+
+    test.each`
+      denom     | lastFeeDenom | expected
+      ${"INIT"} | ${null}      | ${toBaseUnit("99", { decimals: 6 })}
+      ${"INIT"} | ${"INIT"}    | ${toBaseUnit("99", { decimals: 6 })}
+      ${"INIT"} | ${"USDC"}    | ${toBaseUnit("99", { decimals: 6 })}
+      ${"USDC"} | ${null}      | ${toBaseUnit("0.01", { decimals: 6 })}
+      ${"USDC"} | ${"INIT"}    | ${toBaseUnit("0.01", { decimals: 6 })}
+      ${"USDC"} | ${"USDC"}    | ${toBaseUnit("0.01", { decimals: 6 })}
+    `(
+      "returns $expected when sending $denom with lastFeeDenom=$lastFeeDenom",
+      ({ denom, lastFeeDenom, expected }) => {
+        const result = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
+        expect(result).toBe(expected)
+      },
+    )
+  })
+
+  describe("Balance 100 INIT + 100 USDC", () => {
     const balances = [
       { denom: "INIT", amount: String(100 * 1e6) },
       { denom: "USDC", amount: String(100 * 1e6) },
     ]
 
-    const lastFeeDenom = "INIT"
-    const denom = "INIT"
-
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
-
-    expect(maxAmount).toBe(toBaseUnit("99.997", { decimals: 6 }))
+    test.each`
+      denom     | lastFeeDenom | expected
+      ${"INIT"} | ${null}      | ${toBaseUnit("100", { decimals: 6 })}
+      ${"INIT"} | ${"INIT"}    | ${toBaseUnit("99", { decimals: 6 })}
+      ${"INIT"} | ${"USDC"}    | ${toBaseUnit("100", { decimals: 6 })}
+      ${"USDC"} | ${null}      | ${toBaseUnit("100", { decimals: 6 })}
+      ${"USDC"} | ${"INIT"}    | ${toBaseUnit("100", { decimals: 6 })}
+      ${"USDC"} | ${"USDC"}    | ${toBaseUnit("98", { decimals: 6 })}
+    `(
+      "returns $expected when sending $denom with lastFeeDenom=$lastFeeDenom",
+      ({ denom, lastFeeDenom, expected }) => {
+        const result = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
+        expect(result).toBe(expected)
+      },
+    )
   })
 
-  it("should return full balance when lastFeeDenom differs from denom and lastFeeDenom has enough balance", () => {
+  describe("Balance 100 INIT + 100 USDC + 100 ETH", () => {
     const balances = [
       { denom: "INIT", amount: String(100 * 1e6) },
       { denom: "USDC", amount: String(100 * 1e6) },
+      { denom: "ETH", amount: String(100 * 1e6) },
     ]
 
-    const lastFeeDenom = "INIT"
-    const denom = "USDC"
-
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
-
-    expect(maxAmount).toBe(toBaseUnit("100", { decimals: 6 }))
-  })
-
-  it("should return full balance when lastFeeDenom differs from denom", () => {
-    const balances = [{ denom: "USDC", amount: String(100 * 1e6) }]
-
-    const lastFeeDenom = "INIT"
-    const denom = "USDC"
-
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
-
-    expect(maxAmount).toBe(toBaseUnit("99.994", { decimals: 6 }))
-  })
-
-  it("should deduct fee from current token when lastFeeDenom has insufficient balance", () => {
-    const balances = [
-      { denom: "INIT", amount: String(0.001 * 1e6) }, // Insufficient for gas
-      { denom: "USDC", amount: String(100 * 1e6) },
-    ]
-
-    const lastFeeDenom = "INIT"
-    const denom = "USDC"
-
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
-
-    expect(maxAmount).toBe(toBaseUnit("99.994", { decimals: 6 }))
-  })
-
-  it("should return full balance when token cannot be used for gas", () => {
-    const balances = [
-      { denom: "INIT", amount: String(100 * 1e6) },
-      { denom: "USDC", amount: String(100 * 1e6) },
-      { denom: "TOKEN", amount: String(50 * 1e6) }, // Not in gasPrices
-    ]
-
-    const lastFeeDenom = "INIT"
-    const denom = "TOKEN"
-
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
-
-    expect(maxAmount).toBe(toBaseUnit("50", { decimals: 6 }))
-  })
-
-  it("should return 0 when same token has insufficient balance for gas fee", () => {
-    const balances = [
-      { denom: "INIT", amount: String(0.001 * 1e6) }, // Insufficient for gas
-    ]
-
-    const lastFeeDenom = "INIT"
-    const denom = "INIT"
-
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
-
-    expect(maxAmount).toBe("0")
-  })
-
-  it("should return 0 when different token has insufficient balance for gas fee", () => {
-    const balances = [
-      { denom: "INIT", amount: String(0.001 * 1e6) }, // Insufficient for gas
-      { denom: "USDC", amount: String(0.001 * 1e6) }, // Insufficient for gas
-    ]
-
-    const lastFeeDenom = "INIT"
-    const denom = "USDC"
-
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
-
-    expect(maxAmount).toBe("0")
-  })
-
-  it("should return full balance for INIT when lastFeeDenom is null and both have enough for gas", () => {
-    const balances = [
-      { denom: "INIT", amount: String(100 * 1e6) },
-      { denom: "USDC", amount: String(100 * 1e6) },
-    ]
-
-    const lastFeeDenom = null
-    const denom = "INIT"
-
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
-
-    expect(maxAmount).toBe(toBaseUnit("99.997", { decimals: 6 }))
-  })
-
-  it("should return full balance for USDC when lastFeeDenom is null and both have enough for gas", () => {
-    const balances = [
-      { denom: "INIT", amount: String(100 * 1e6) },
-      { denom: "USDC", amount: String(100 * 1e6) },
-    ]
-
-    const lastFeeDenom = null
-    const denom = "USDC"
-
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
-
-    expect(maxAmount).toBe(toBaseUnit("100", { decimals: 6 }))
-  })
-
-  it("should deduct fee from self when lastFeeDenom is null and only one fee token exists", () => {
-    const balances = [{ denom: "INIT", amount: String(100 * 1e6) }]
-    const lastFeeDenom = null
-
-    const maxAmount = calcMaxAmount({ denom: "INIT", balances, gasPrices, lastFeeDenom, gas })
-    expect(maxAmount).toBe(toBaseUnit("99.997", { decimals: 6 }))
+    test.each`
+      denom    | lastFeeDenom | expected
+      ${"ETH"} | ${null}      | ${toBaseUnit("100", { decimals: 6 })}
+      ${"ETH"} | ${"INIT"}    | ${toBaseUnit("100", { decimals: 6 })}
+      ${"ETH"} | ${"USDC"}    | ${toBaseUnit("100", { decimals: 6 })}
+    `(
+      "returns $expected when sending $denom with lastFeeDenom=$lastFeeDenom",
+      ({ denom, lastFeeDenom, expected }) => {
+        const result = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
+        expect(result).toBe(expected)
+      },
+    )
   })
 })

--- a/packages/interwovenkit-react/src/pages/wallet/txs/send/max.test.ts
+++ b/packages/interwovenkit-react/src/pages/wallet/txs/send/max.test.ts
@@ -7,6 +7,8 @@ describe("getMaxAmount", () => {
     { denom: "USDC", amount: "0.03" },
   ]
 
+  const gas = 200000
+
   it("should deduct fee from same token balance when lastFeeDenom equals denom", () => {
     const balances = [
       { denom: "INIT", amount: String(100 * 1e6) },
@@ -16,7 +18,7 @@ describe("getMaxAmount", () => {
     const lastFeeDenom = "INIT"
     const denom = "INIT"
 
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
 
     expect(maxAmount).toBe(toBaseUnit("99.997", { decimals: 6 }))
   })
@@ -30,7 +32,7 @@ describe("getMaxAmount", () => {
     const lastFeeDenom = "INIT"
     const denom = "USDC"
 
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
 
     expect(maxAmount).toBe(toBaseUnit("100", { decimals: 6 }))
   })
@@ -41,7 +43,7 @@ describe("getMaxAmount", () => {
     const lastFeeDenom = "INIT"
     const denom = "USDC"
 
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
 
     expect(maxAmount).toBe(toBaseUnit("99.994", { decimals: 6 }))
   })
@@ -55,7 +57,7 @@ describe("getMaxAmount", () => {
     const lastFeeDenom = "INIT"
     const denom = "USDC"
 
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
 
     expect(maxAmount).toBe(toBaseUnit("99.994", { decimals: 6 }))
   })
@@ -70,7 +72,7 @@ describe("getMaxAmount", () => {
     const lastFeeDenom = "INIT"
     const denom = "TOKEN"
 
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
 
     expect(maxAmount).toBe(toBaseUnit("50", { decimals: 6 }))
   })
@@ -83,7 +85,7 @@ describe("getMaxAmount", () => {
     const lastFeeDenom = "INIT"
     const denom = "INIT"
 
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
 
     expect(maxAmount).toBe("0")
   })
@@ -97,7 +99,7 @@ describe("getMaxAmount", () => {
     const lastFeeDenom = "INIT"
     const denom = "USDC"
 
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
 
     expect(maxAmount).toBe("0")
   })
@@ -111,7 +113,7 @@ describe("getMaxAmount", () => {
     const lastFeeDenom = null
     const denom = "INIT"
 
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
 
     expect(maxAmount).toBe(toBaseUnit("99.997", { decimals: 6 }))
   })
@@ -125,7 +127,7 @@ describe("getMaxAmount", () => {
     const lastFeeDenom = null
     const denom = "USDC"
 
-    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom, balances, gasPrices, lastFeeDenom, gas })
 
     expect(maxAmount).toBe(toBaseUnit("100", { decimals: 6 }))
   })
@@ -134,7 +136,7 @@ describe("getMaxAmount", () => {
     const balances = [{ denom: "INIT", amount: String(100 * 1e6) }]
     const lastFeeDenom = null
 
-    const maxAmount = calcMaxAmount({ denom: "INIT", balances, gasPrices, lastFeeDenom })
+    const maxAmount = calcMaxAmount({ denom: "INIT", balances, gasPrices, lastFeeDenom, gas })
     expect(maxAmount).toBe(toBaseUnit("99.997", { decimals: 6 }))
   })
 })

--- a/packages/interwovenkit-react/src/pages/wallet/txs/send/max.ts
+++ b/packages/interwovenkit-react/src/pages/wallet/txs/send/max.ts
@@ -1,18 +1,18 @@
 import type { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin"
 import BigNumber from "bignumber.js"
 
-export const FIXED_GAS = 200000
-
 function createAvailableFeeOptions({
   balances,
   gasPrices,
+  gas,
 }: {
   balances: Coin[]
   gasPrices: Coin[]
+  gas: number
 }) {
   return gasPrices
     .map(({ denom, amount: price }) => {
-      const amount = BigNumber(price).times(FIXED_GAS).toFixed(0, BigNumber.ROUND_CEIL)
+      const amount = BigNumber(price).times(gas).toFixed(0, BigNumber.ROUND_CEIL)
       const balance = balances.find((coin) => coin.denom === denom)?.amount ?? "0"
       return { amount, denom, balance }
     })
@@ -24,14 +24,16 @@ export function calcMaxAmount({
   balances,
   gasPrices,
   lastFeeDenom,
+  gas,
 }: {
   denom: string
   balances: Coin[]
   gasPrices: Coin[]
   lastFeeDenom: string | null
+  gas: number
 }) {
   const balance = balances.find((coin) => coin.denom === denom)?.amount ?? "0"
-  const availableFeeOptions = createAvailableFeeOptions({ balances, gasPrices })
+  const availableFeeOptions = createAvailableFeeOptions({ balances, gasPrices, gas })
   const lastFeeOption = availableFeeOptions.find((option) => option.denom === lastFeeDenom)
 
   if (availableFeeOptions.length === 0) {

--- a/packages/interwovenkit-react/src/pages/wallet/txs/send/max.ts
+++ b/packages/interwovenkit-react/src/pages/wallet/txs/send/max.ts
@@ -45,7 +45,8 @@ export function calcMaxAmount({
     return BigNumber.max(amount, 0).toString()
   }
 
-  const [preferredFeeOption] = availableFeeOptions
+  const preferredFeeOption =
+    availableFeeOptions.find((option) => option.denom !== denom) || availableFeeOptions[0]
   if (!lastFeeOption && denom === preferredFeeOption.denom) {
     const amount = BigNumber(balance).minus(preferredFeeOption.amount)
     return BigNumber.max(amount, 0).toString()


### PR DESCRIPTION
## Summary
- Improved the max send amount calculation logic to intelligently select fee tokens
- When `lastFeeDenom` is not specified, the system now prefers using alternative fee tokens over the token being sent
- This allows users to send their entire balance when other fee tokens are available

## Test plan
- [x] All existing tests pass
- [x] Added comprehensive test cases covering various balance scenarios
- [x] Tested with multiple fee token options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The balance button now supports a disabled state, visually indicating when it cannot be interacted with.
  * Maximum sendable amount is now calculated using real-time gas estimation, providing more accurate results based on current network conditions.

* **Bug Fixes**
  * The "Max" balance button is disabled while gas estimation is loading, preventing premature actions.

* **Refactor**
  * Improved logic for fee calculation and preferred fee token selection when sending transactions.
  * Test suite for maximum amount calculation was reorganized for better clarity and coverage.
  * Conditional rendering refined to avoid displaying incomplete amounts in route selection.

* **Enhancements**
  * Transactions on the "initia" chain now include explicit coin spending details for improved processing accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->