### PR TITLE
feat: improve bridge page navigation

### DIFF
--- a/packages/interwovenkit-react/src/components/Page.tsx
+++ b/packages/interwovenkit-react/src/components/Page.tsx
@@ -6,16 +6,16 @@ import styles from "./Page.module.css"
 
 interface Props {
   title: string
-  returnTo?: string | false
+  backButton?: ReactNode
   extra?: ReactNode
 }
 
-const Page = ({ title, returnTo, extra, children }: PropsWithChildren<Props>) => {
+const Page = ({ title, backButton, extra, children }: PropsWithChildren<Props>) => {
   return (
     <>
       <header className={styles.header}>
-        {returnTo !== false && (
-          <Link to={returnTo ?? -1} className={styles.back}>
+        {backButton ?? (
+          <Link to={-1} className={styles.back}>
             <IconBack size={16} />
           </Link>
         )}

--- a/packages/interwovenkit-react/src/lib/router/Link.tsx
+++ b/packages/interwovenkit-react/src/lib/router/Link.tsx
@@ -1,18 +1,24 @@
 import type { ButtonHTMLAttributes, MouseEvent } from "react"
-import { useNavigate } from "./RouterContext"
+import { useNavigate, useReset } from "./RouterContext"
 
 export interface LinkProp extends ButtonHTMLAttributes<HTMLButtonElement> {
   to: string | number
   state?: object
+  shouldReset?: boolean
 }
 
-const Link = ({ to, state, children, onClick, ...attrs }: LinkProp) => {
+const Link = ({ to, state, shouldReset, children, onClick, ...attrs }: LinkProp) => {
   const navigate = useNavigate()
+  const reset = useReset()
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault()
     onClick?.(event)
-    navigate(to, state)
+    if (shouldReset) {
+      reset(to as string, state)
+    } else {
+      navigate(to, state)
+    }
   }
 
   return (

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeForm.module.css
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeForm.module.css
@@ -1,0 +1,18 @@
+.backButton {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+
+  background: var(--gray-6);
+  border-radius: 4px;
+  color: var(--gray-1);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 8px;
+
+  transition: background-color var(--transition) ease;
+
+  &:hover {
+    background: var(--gray-5);
+  }
+}

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeForm.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeForm.tsx
@@ -5,7 +5,8 @@ import { useQueryClient } from "@tanstack/react-query"
 import { FormProvider, useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import type { BalancesResponseJson } from "@skip-go/client"
-import { useHistory, useNavigate } from "@/lib/router"
+import { IconBack } from "@initia/icons-react"
+import { Link, useHistory, useNavigate } from "@/lib/router"
 import { useAddress } from "@/public/data/hooks"
 import { LocalStorageKey } from "@/data/constants"
 import { useDrawer } from "@/data/ui"
@@ -24,6 +25,7 @@ import { useSkipAssets } from "./data/assets"
 import { skipQueryKeys } from "./data/skip"
 import { useClaimableModal, useClaimableReminders } from "./op/reminder"
 import BridgeFields from "./BridgeFields"
+import styles from "./BridgeForm.module.css"
 
 const BridgeForm = () => {
   useClaimableModal()
@@ -133,10 +135,15 @@ const BridgeForm = () => {
 
   return (
     <Page
-      title="Bridge/Swap"
-      // The previous page may not be the intended destination.
-      // To avoid unexpected behavior, it explicitly returns to the wallet page.
-      returnTo={isBridge ? false : "/"}
+      title={isBridge ? "" : "Bridge/Swap"}
+      backButton={
+        isBridge ? (
+          <Link to="/" className={styles.backButton} shouldReset>
+            <IconBack size={12} />
+            <span>Wallet</span>
+          </Link>
+        ) : undefined
+      }
       extra={
         <>
           <Button.Small onClick={() => navigate("/bridge/history")} unpadded>


### PR DESCRIPTION
- Replace returnTo prop with backButton in Page component for flexible navigation
- Add shouldReset option to Link component for router state reset
- Add custom back button to bridge page with wallet shortcut
- Style back button with proper hover state and transitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pages now support a customizable back button with a sensible default.
* **UI/UX**
  * Bridge screen shows a clear, styled back button to return to the Wallet.
  * Header behavior refined on Bridge routes for a cleaner layout.
* **Navigation**
  * Improved back navigation flow on Bridge, resetting state to avoid confusing history.
* **Style**
  * Added consistent styling for the back button to match the app’s theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->