### PR TITLE
feat: add useDisconnect hook with localStorage cleanup

### DIFF
--- a/packages/interwovenkit-react/src/data/ui.ts
+++ b/packages/interwovenkit-react/src/data/ui.ts
@@ -1,6 +1,8 @@
+import { useDisconnect as useDisconnectWagmi } from "wagmi"
 import { atom, useAtom } from "jotai"
-import { useReset } from "@/lib/router"
+import { useNavigate, useReset } from "@/lib/router"
 import { useAnalyticsTrack } from "@/data/analytics"
+import { LocalStorageKey } from "./constants"
 
 const isDrawerOpenAtom = atom<boolean>(false)
 
@@ -23,4 +25,24 @@ export function useDrawer() {
   }
 
   return { isDrawerOpen: isOpen, openDrawer: open, closeDrawer: close }
+}
+
+export function useDisconnect() {
+  const navigate = useNavigate()
+  const { closeDrawer } = useDrawer()
+  const { disconnect } = useDisconnectWagmi()
+
+  return () => {
+    navigate("/blank")
+    closeDrawer()
+    disconnect()
+
+    // Clear bridge form values on disconnect
+    localStorage.removeItem(LocalStorageKey.BRIDGE_SRC_CHAIN_ID)
+    localStorage.removeItem(LocalStorageKey.BRIDGE_SRC_DENOM)
+    localStorage.removeItem(LocalStorageKey.BRIDGE_DST_CHAIN_ID)
+    localStorage.removeItem(LocalStorageKey.BRIDGE_DST_DENOM)
+    localStorage.removeItem(LocalStorageKey.BRIDGE_QUANTITY)
+    localStorage.removeItem(LocalStorageKey.BRIDGE_SLIPPAGE_PERCENT)
+  }
 }

--- a/packages/interwovenkit-react/src/public/app/WidgetHeader.tsx
+++ b/packages/interwovenkit-react/src/public/app/WidgetHeader.tsx
@@ -1,13 +1,11 @@
 import clsx from "clsx"
-import { useAccount, useDisconnect } from "wagmi"
+import { useAccount } from "wagmi"
 import { useState, useRef, useEffect } from "react"
 import { useSpring, animated } from "@react-spring/web"
 import { IconCopy, IconQrCode, IconSignOut } from "@initia/icons-react"
 import { truncate } from "@initia/utils"
-import { useNavigate } from "@/lib/router"
 import { useInterwovenKit } from "@/public/data/hooks"
-import { useDrawer } from "@/data/ui"
-import { LocalStorageKey } from "@/data/constants"
+import { useDisconnect } from "@/data/ui"
 import { useDefaultChain } from "@/data/chains"
 import CopyButton from "@/components/CopyButton"
 import Image from "@/components/Image"
@@ -16,12 +14,10 @@ import AddressQr from "./AddressQr"
 import styles from "./WidgetHeader.module.css"
 
 const WidgetHeader = () => {
-  const navigate = useNavigate()
   const deafultChain = useDefaultChain()
   const { connector } = useAccount()
-  const { disconnect } = useDisconnect()
+  const disconnect = useDisconnect()
   const { address, username } = useInterwovenKit()
-  const { closeDrawer } = useDrawer()
   const { openModal } = useModal()
   const name = username ?? address
 
@@ -37,17 +33,7 @@ const WidgetHeader = () => {
     if (!isExpanded) {
       setIsExpanded(true)
     } else {
-      navigate("/blank")
-      closeDrawer()
       disconnect()
-
-      // Clear bridge form values on disconnect
-      localStorage.removeItem(LocalStorageKey.BRIDGE_SRC_CHAIN_ID)
-      localStorage.removeItem(LocalStorageKey.BRIDGE_SRC_DENOM)
-      localStorage.removeItem(LocalStorageKey.BRIDGE_DST_CHAIN_ID)
-      localStorage.removeItem(LocalStorageKey.BRIDGE_DST_DENOM)
-      localStorage.removeItem(LocalStorageKey.BRIDGE_QUANTITY)
-      localStorage.removeItem(LocalStorageKey.BRIDGE_SLIPPAGE_PERCENT)
     }
   }
 

--- a/packages/interwovenkit-react/src/public/data/hooks.ts
+++ b/packages/interwovenkit-react/src/public/data/hooks.ts
@@ -2,7 +2,7 @@ import { useAccount } from "wagmi"
 import { useQuery } from "@tanstack/react-query"
 import { InitiaAddress } from "@initia/utils"
 import { useTx } from "@/data/tx"
-import { useDrawer } from "@/data/ui"
+import { useDisconnect, useDrawer } from "@/data/ui"
 import { useDefaultChain } from "@/data/chains"
 import { useOfflineSigner } from "@/data/signer"
 import { accountQueryKeys, useUsernameClient } from "@/data/account"
@@ -50,6 +50,7 @@ export function useInterwovenKit() {
   const hexAddress = useHexAddress()
   const { data: username } = useUsernameQuery()
   const offlineSigner = useOfflineSigner()
+  const disconnect = useDisconnect()
 
   const { isDrawerOpen: isOpen, openDrawer } = useDrawer()
 
@@ -77,6 +78,7 @@ export function useInterwovenKit() {
     openConnect,
     openWallet,
     openBridge,
+    disconnect,
     ...tx,
   }
 }


### PR DESCRIPTION
- Create centralized useDisconnect hook in ui.ts that handles wallet disconnection
- Clear all bridge-related localStorage values on disconnect
- Refactor WidgetHeader to use the new useDisconnect hook
- Export disconnect function from useInterwovenKit for external usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a one-click Disconnect action in the widget header.
  - Exposed a disconnect() function in useInterwovenKit(), enabling apps to trigger disconnection programmatically.
  - Disconnect now performs consistent session cleanup for a fresh start.

- Refactor
  - Centralized the disconnect flow into a single hook to ensure uniform behavior across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->