### PR TITLE
refactor(wallet): improve privy wallet connector display logic

### DIFF
--- a/packages/interwovenkit-react/src/pages/connect/Connect.tsx
+++ b/packages/interwovenkit-react/src/pages/connect/Connect.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 import { useReadLocalStorage } from "usehooks-ts"
 import { useMutation } from "@tanstack/react-query"
 import { IconExternalLink } from "@initia/icons-react"
+import { initiaPrivyWalletOptions } from "@/public/data/connectors"
 import { normalizeError } from "@/data/http"
 import Scrollable from "@/components/Scrollable"
 import Image from "@/components/Image"
@@ -63,7 +64,7 @@ const Connect = ({ onSuccess }: { onSuccess?: () => void }) => {
                     <Loader size={16} />
                   ) : recentConnectorId === id ? (
                     <span className={styles.recent}>Recent</span>
-                  ) : connector.name === "Google" ? null : (
+                  ) : connector.id === initiaPrivyWalletOptions.id ? null : (
                     <span className={styles.installed}>Installed</span>
                   )}
                 </button>

--- a/packages/interwovenkit-react/src/public/data/connectors.ts
+++ b/packages/interwovenkit-react/src/public/data/connectors.ts
@@ -2,8 +2,8 @@ import { toPrivyWallet, toPrivyWalletConnector } from "@privy-io/cross-app-conne
 
 export const initiaPrivyWalletOptions = {
   id: "cmbq1ozyc006al70lx4uciz0q",
-  name: "Google",
-  iconUrl: "https://assets.initia.xyz/images/wallets/Google.webp",
+  name: "Socials & Passkeys",
+  iconUrl: "https://assets.initia.xyz/images/wallets/Privy.webp",
   iconBackground: "#ffffff",
 }
 


### PR DESCRIPTION
- Update connector name from "Google" to "Socials & Passkeys"
- Change icon from Google to Privy branding
- Replace name-based condition with id-based condition for better reliability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected the “Installed” badge logic to apply appropriately for the Socials & Passkeys connector.

- Style
  - Renamed the Google wallet option to “Socials & Passkeys.”
  - Updated the connector icon to the Privy asset for a refreshed look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->