### PR TITLE
feat: add staging env

### DIFF
--- a/examples/vite/src/Providers.tsx
+++ b/examples/vite/src/Providers.tsx
@@ -9,7 +9,7 @@ import {
   TESTNET,
 } from "@initia/interwovenkit-react"
 import css from "@initia/interwovenkit-react/styles.css?inline"
-import { isTestnet, useTheme } from "./data"
+import { isStaging, isTestnet, useTheme } from "./data"
 
 injectStyles(css)
 const wagmiConfig = createConfig({
@@ -25,6 +25,7 @@ const Providers = ({ children }: PropsWithChildren) => {
     <QueryClientProvider client={queryClient}>
       <WagmiProvider config={wagmiConfig}>
         <InterwovenKitProvider
+          {...(isStaging ? { routerApiUrl: "https://router-api.staging.initia.xyz" } : {})}
           {...(isTestnet ? TESTNET : {})}
           theme={theme}
           container={import.meta.env.DEV ? document.body : undefined}

--- a/examples/vite/src/data.ts
+++ b/examples/vite/src/data.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react"
 import { atom, useAtomValue } from "jotai"
 
 export const isTestnet = import.meta.env.INITIA_NETWORK_TYPE === "testnet"
+export const isStaging = import.meta.env.INITIA_NETWORK_TYPE === "staging"
 export const themeAtom = atom<"light" | "dark">("dark")
 export function useTheme() {
   const theme = useAtomValue(themeAtom)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for a “staging” network environment via environment variable. When set to staging, the app automatically uses the staging router API endpoint for requests.
  - Default behavior for non-staging environments is unchanged.

- Chores
  - Introduced a simple environment-based flag to enable staging configuration without impacting existing testnet or theme settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->