### PR TITLE
refactor(modal,drawer): replace spring animations with CSS transitions

### DIFF
--- a/packages/interwovenkit-react/src/components/Modal.module.css
+++ b/packages/interwovenkit-react/src/components/Modal.module.css
@@ -1,12 +1,15 @@
 .overlay {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
 
   background-color: rgba(0, 0, 0, 0.7);
   z-index: var(--z-index);
+  transition: opacity var(--transition) cubic-bezier(0.4, 0, 0.2, 1);
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+  }
 }
 
 .overlay.fullscreen {
@@ -29,6 +32,14 @@
   overflow: hidden;
   min-height: 360px;
   max-height: calc(100% - 2 * 16px);
+  transition: all var(--transition) cubic-bezier(0.4, 0, 0.2, 1);
+  transition-property: opacity, transform;
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: translateY(24px);
+  }
 }
 
 .content.fullscreen {

--- a/packages/interwovenkit-react/src/components/Modal.tsx
+++ b/packages/interwovenkit-react/src/components/Modal.tsx
@@ -1,8 +1,7 @@
 import clsx from "clsx"
 import type { ReactNode } from "react"
-import { useContext, useEffect } from "react"
-import { createPortal } from "react-dom"
-import { useTransition, animated } from "@react-spring/web"
+import { useContext } from "react"
+import { Dialog } from "@base-ui-components/react/dialog"
 import { IconClose } from "@initia/icons-react"
 import { usePortal } from "@/public/app/PortalContext"
 import { fullscreenContext } from "@/public/app/fullscreen"
@@ -21,89 +20,32 @@ const Modal = ({ title, children, trigger, className, open, onOpenChange }: Prop
   const portal = usePortal()
   const fullscreen = useContext(fullscreenContext)
 
-  useEffect(() => {
-    if (!open) return
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onOpenChange(false)
-      }
-    }
-
-    document.addEventListener("keydown", handleKeyDown)
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown)
-    }
-  }, [onOpenChange, open])
-
-  const overlayTransitions = useTransition(open, {
-    from: { opacity: 0 },
-    enter: { opacity: 1 },
-    leave: { opacity: 0 },
-    config: { tension: 500, friction: 30, clamp: true },
-  })
-
-  const contentTransitions = useTransition(open, {
-    from: { opacity: 0, transform: "translateY(24px)" },
-    enter: { opacity: 1, transform: "translateY(0px)" },
-    leave: { opacity: 0, transform: "translateY(24px)" },
-    config: { tension: 500, friction: 30, clamp: true },
-  })
-
   if (!portal) return null
 
   return (
-    <>
-      {trigger && (
-        <button type="button" className={className} onClick={() => onOpenChange(true)}>
-          {trigger}
-        </button>
-      )}
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      {trigger && <Dialog.Trigger className={className}>{trigger}</Dialog.Trigger>}
 
-      {createPortal(
-        <>
-          {overlayTransitions(
-            (style, item) =>
-              item && (
-                <animated.div
-                  style={style}
-                  className={clsx(styles.overlay, { [styles.fullscreen]: fullscreen })}
-                  onClick={() => onOpenChange(false)}
-                  onKeyDown={() => onOpenChange(false)}
-                  role="button"
-                  tabIndex={0}
-                />
-              ),
+      <Dialog.Portal container={portal}>
+        <Dialog.Backdrop
+          className={clsx(styles.overlay, { [styles.fullscreen]: fullscreen })}
+          forceRender
+        />
+
+        <Dialog.Popup className={clsx(styles.content, { [styles.fullscreen]: fullscreen })}>
+          {title && (
+            <header className={styles.header}>
+              <Dialog.Title className={styles.title}>{title}</Dialog.Title>
+              <Dialog.Close className={styles.close}>
+                <IconClose size={20} />
+              </Dialog.Close>
+            </header>
           )}
 
-          {contentTransitions(
-            (style, item) =>
-              item && (
-                <animated.div
-                  style={style}
-                  className={clsx(styles.content, { [styles.fullscreen]: fullscreen })}
-                >
-                  {title && (
-                    <header className={styles.header}>
-                      <h2 className={styles.title}>{title}</h2>
-                      <button
-                        type="button"
-                        className={styles.close}
-                        onClick={() => onOpenChange(false)}
-                      >
-                        <IconClose size={20} />
-                      </button>
-                    </header>
-                  )}
-
-                  {children}
-                </animated.div>
-              ),
-          )}
-        </>,
-        portal,
-      )}
-    </>
+          {children}
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
   )
 }
 

--- a/packages/interwovenkit-react/src/public/app/Drawer.module.css
+++ b/packages/interwovenkit-react/src/public/app/Drawer.module.css
@@ -1,58 +1,13 @@
-.overlay {
-  position: fixed;
-  top: var(--drawer-offset);
-  right: var(--drawer-offset);
-  bottom: var(--drawer-offset);
-  width: calc(var(--drawer-width) + 54px);
-  will-change: transform;
-  z-index: var(--z-index);
-
-  display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
-
-  border-radius: var(--border-radius);
-  padding: var(--padding);
-
-  svg {
-    fill: var(--gray-2);
-  }
-
-  transition: background-color var(--transition) ease-in-out;
-
-  &:hover {
-    background-color: rgba(125, 125, 125, 0.1);
-  }
-
-  @media (max-width: 576px) {
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-
-    background-color: rgba(0, 0, 0, 0.8);
-    border-radius: 0;
-    width: 100%;
-    height: 100vh; /* fallback */
-    height: 100dvh;
-
-    svg {
-      transform: rotate(90deg);
-    }
-
-    &:hover {
-      background-color: rgba(0, 0, 0, 0.8);
-    }
-  }
-}
-
 .content {
   position: fixed;
   top: var(--drawer-offset);
   right: var(--drawer-offset);
   bottom: var(--drawer-offset);
-  will-change: transform;
   z-index: var(--z-index);
+
+  transition: all var(--transition) cubic-bezier(0.4, 0, 0.2, 1);
+  transition-property: transform, opacity;
+  will-change: transform;
 
   @media (max-width: 576px) {
     top: 54px;
@@ -61,6 +16,16 @@
     bottom: 0;
     height: calc(100vh - 54px); /* fallback */
     height: calc(100dvh - 54px);
+  }
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: translateX(100%);
+
+    @media (max-width: 576px) {
+      transform: translateY(100%);
+    }
   }
 }
 

--- a/packages/interwovenkit-react/src/public/app/Drawer.tsx
+++ b/packages/interwovenkit-react/src/public/app/Drawer.tsx
@@ -1,15 +1,14 @@
 import clsx from "clsx"
 import { useAtomValue } from "jotai"
 import { useContext, type PropsWithChildren } from "react"
-import { createPortal } from "react-dom"
-import { useIsMobile } from "@/hooks/useIsMobile"
 import type { FallbackProps } from "react-error-boundary"
-import { useTransition, animated } from "@react-spring/web"
+import { Dialog } from "@base-ui-components/react/dialog"
 import { useIsMutating, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, usePath } from "@/lib/router"
 import { LocalStorageKey } from "@/data/constants"
 import { useDrawer } from "@/data/ui"
 import { TX_APPROVAL_MUTATION_KEY, txRequestHandlerAtom } from "@/data/tx"
+import { useIsMobile } from "@/hooks/useIsMobile"
 import AsyncBoundary from "@/components/AsyncBoundary"
 import Scrollable from "@/components/Scrollable"
 import Status from "@/components/Status"
@@ -26,6 +25,7 @@ const Drawer = ({ children }: PropsWithChildren) => {
   const { isDrawerOpen, closeDrawer } = useDrawer()
   const { setContainer } = useContext(PortalContext)
   const isSmall = useIsMobile()
+  const portalContainer = usePortalContainer()
 
   // FIXME: React StrictMode causes a problem by unmounting the component once on purpose.
   // Should reject on unmount, but didn't work as expected.
@@ -33,7 +33,7 @@ const Drawer = ({ children }: PropsWithChildren) => {
   // Would be nice to fix this properly later.
   const txRequest = useAtomValue(txRequestHandlerAtom)
   const isPendingTransaction = useIsMutating({ mutationKey: [TX_APPROVAL_MUTATION_KEY] })
-  const handleOverlayClick = () => {
+  const handleCloseDrawer = () => {
     const errorMessage = isPendingTransaction
       ? "User exited before response arrived. Transaction may succeed or fail."
       : "User rejected"
@@ -73,41 +73,23 @@ const Drawer = ({ children }: PropsWithChildren) => {
     },
   }
 
-  // Animation
-  const drawerTransition = useTransition(isDrawerOpen, {
-    from: { transform: isSmall ? "translateY(100%)" : "translateX(100%)" },
-    enter: { transform: isSmall ? "translateY(0%)" : "translateX(0%)" },
-    leave: { transform: isSmall ? "translateY(100%)" : "translateX(100%)" },
-    config: { tension: 500, friction: 30, clamp: true },
-  })
-
-  return createPortal(
-    <>
-      {drawerTransition((style, item) =>
-        item ? (
-          <animated.button style={style} className={styles.overlay} onClick={handleOverlayClick}>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14" height="14">
-              <path d="M7.168 14.04 l 6.028 -6.028 l -6.028 -6.028 L8.57 .582 L16 8.012 l -7.43 7.43 l -1.402 -1.402 Z" />
-              <path d="M0.028 14.04 l 6.028 -6.028 L0.028 1.984 L1.43 .582 l 7.43 7.43 l -7.43 7.43 L0.028 14.04 Z" />
-            </svg>
-          </animated.button>
-        ) : null,
-      )}
-
-      {drawerTransition((style, item) =>
-        item ? (
-          <animated.div style={style} className={clsx(styles.content)}>
-            <div className={clsx(styles.inner, "body")} ref={setContainer}>
-              {isSmall && <ScrollLock />}
-              <TxWatcher />
-              <WidgetHeader />
-              <AsyncBoundary errorBoundaryProps={errorBoundaryProps}>{children}</AsyncBoundary>
-            </div>
-          </animated.div>
-        ) : null,
-      )}
-    </>,
-    usePortalContainer(),
+  return (
+    <Dialog.Root
+      open={isDrawerOpen}
+      onOpenChange={(open) => !open && handleCloseDrawer()}
+      modal={false}
+    >
+      <Dialog.Portal container={portalContainer}>
+        <Dialog.Popup className={styles.content}>
+          <div className={clsx(styles.inner, "body")} ref={setContainer}>
+            {isSmall && <ScrollLock />}
+            <TxWatcher />
+            <WidgetHeader />
+            <AsyncBoundary errorBoundaryProps={errorBoundaryProps}>{children}</AsyncBoundary>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
   )
 }
 


### PR DESCRIPTION
Remove react-spring dependency and use Base UI native CSS animations for simpler and more performant modal/drawer transitions