### PR TITLE
feat(interwovenkit): add custom fee handling support

### DIFF
--- a/packages/interwovenkit-react/README.md
+++ b/packages/interwovenkit-react/README.md
@@ -169,6 +169,42 @@ export default function Home() {
 }
 ```
 
+## Custom Fee Handling
+
+When you need to bypass the fee selection UI and use pre-calculated fees directly:
+
+```tsx
+// page.tsx
+"use client"
+
+import { calculateFee, GasPrice } from "@cosmjs/stargate"
+import { useInterwovenKit } from "@initia/interwovenkit-react"
+
+export default function Home() {
+  const { address, estimateGas, signAndBroadcastTx } = useInterwovenKit()
+
+  const send = async () => {
+    const messages = [
+      {
+        typeUrl: "/cosmos.bank.v1beta1.MsgSend",
+        value: {
+          fromAddress: address,
+          toAddress: address,
+          amount: [{ amount: "1000000", denom: "uinit" }],
+        },
+      },
+    ]
+
+    const gas = await estimateGas({ messages })
+    const fee = calculateFee(gas, GasPrice.fromString("0.015uinit"))
+    const { transactionHash } = await signAndBroadcastTx({ messages, fee })
+    console.log("Transaction sent:", transactionHash)
+  }
+
+  return <button onClick={send}>Send</button>
+}
+```
+
 ## Usage on Testnet
 
 ```tsx


### PR DESCRIPTION
- Add TxParams interface for direct fee specification
- Export signAndBroadcastTx function for bypassing fee UI
- Include usage documentation with practical example
- Enable pre-calculated fee workflows for advanced users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new API to sign and broadcast transactions directly, complementing existing transaction helpers. Requires an explicit fee to be provided.

* **Documentation**
  * Added a “Custom Fee Handling” guide showing how to bypass the fee selection UI by calculating and applying fees manually, with a complete usage example for estimating gas, deriving fees, and broadcasting a transaction.
  * No runtime behavior changes; documentation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->