### PR TITLE
fix: increase sequence in op hook if srcChain == opChain

### DIFF
--- a/packages/interwovenkit-react/src/data/signer.ts
+++ b/packages/interwovenkit-react/src/data/signer.ts
@@ -127,6 +127,7 @@ export function useSignWithEthSecp256k1() {
     messages: readonly EncodeObject[],
     fee: StdFee,
     memo: string,
+    options: { increaseSequence?: boolean },
   ): Promise<TxRaw> {
     if (!signer) throw new Error("Signer not initialized")
     const client = await createSigningStargateClient(chainId)
@@ -141,7 +142,14 @@ export function useSignWithEthSecp256k1() {
     /* 1 */ const pubkey = encodePubkeyInitia(encodeEthSecp256k1Pubkey(accountFromSigner.pubkey))
     /* 2 */ const signMode = SignMode.SIGN_MODE_EIP_191
     const msgs = messages.map((msg) => aminoTypes.toAmino(msg))
-    const signDoc = makeSignDocAmino(msgs, fee, chainId, memo, accountNumber, sequence)
+    const signDoc = makeSignDocAmino(
+      msgs,
+      fee,
+      chainId,
+      memo,
+      accountNumber,
+      sequence + (options.increaseSequence ? 1 : 0),
+    )
     const { signature, signed } = await signer.signAmino(signerAddress, signDoc)
     const signedTxBody = {
       messages: signed.msgs.map((msg) => aminoTypes.fromAmino(msg)),

--- a/packages/interwovenkit-react/src/data/signer.ts
+++ b/packages/interwovenkit-react/src/data/signer.ts
@@ -127,7 +127,7 @@ export function useSignWithEthSecp256k1() {
     messages: readonly EncodeObject[],
     fee: StdFee,
     memo: string,
-    options: { increaseSequence?: boolean },
+    options?: { increaseSequence?: boolean },
   ): Promise<TxRaw> {
     if (!signer) throw new Error("Signer not initialized")
     const client = await createSigningStargateClient(chainId)
@@ -148,7 +148,7 @@ export function useSignWithEthSecp256k1() {
       chainId,
       memo,
       accountNumber,
-      sequence + (options.increaseSequence ? 1 : 0),
+      sequence + (options?.increaseSequence ? 1 : 0),
     )
     const { signature, signed } = await signer.signAmino(signerAddress, signDoc)
     const signedTxBody = {

--- a/packages/interwovenkit-react/src/pages/bridge/data/tx.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/tx.ts
@@ -283,6 +283,9 @@ export function useSignOpHook() {
           messages,
           { amount: [], gas: "1" },
           "",
+          {
+            increaseSequence: chain_id === values.srcChainId,
+          },
         )
 
         const tx = Tx.fromPartial({

--- a/packages/interwovenkit-react/src/pages/bridge/data/tx.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/tx.ts
@@ -277,15 +277,15 @@ export function useSignOpHook() {
           })
         })
 
+        // When bridging from the same chain where the op hook is executed,
+        // increment the sequence to prevent nonce conflicts in concurrent transactions
         const signed = await signWithEthSecp256k1(
           chain_id,
           initiaAddress,
           messages,
           { amount: [], gas: "1" },
           "",
-          {
-            increaseSequence: chain_id === values.srcChainId,
-          },
+          { incrementSequence: chain_id === values.srcChainId },
         )
 
         const tx = Tx.fromPartial({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improvements
  - Transaction signing now includes an optional sequence-increment option; bridge signing enables this on the source chain to better handle concurrent transactions.

- Bug Fixes
  - Reduced account sequence mismatch errors during signing, improving submission reliability and reducing retries for bridge transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->