### PR TITLE
feat(bridge): group history items by date

### DIFF
--- a/packages/interwovenkit-react/src/data/date.ts
+++ b/packages/interwovenkit-react/src/data/date.ts
@@ -1,0 +1,24 @@
+export function groupByDate<T>(
+  items: T[],
+  getDate: (item: T) => Date | undefined,
+): Record<string, T[]> {
+  return items.reduce(
+    (groups, item) => {
+      const date = getDate(item)
+      if (!date) return groups
+
+      const dateKey = date.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+
+      const existingGroup = groups[dateKey] || []
+      return {
+        ...groups,
+        [dateKey]: [...existingGroup, item],
+      }
+    },
+    {} as Record<string, T[]>,
+  )
+}

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.module.css
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.module.css
@@ -1,5 +1,7 @@
-.list {
-  margin: calc(-1 * var(--padding));
+.history {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .header {
@@ -10,6 +12,18 @@
   padding: 12px var(--padding);
 }
 
-.item {
-  border-bottom: 1px solid var(--border);
+.dateGroup {
+  display: grid;
+  gap: 8px;
+}
+
+.dateHeader {
+  color: var(--gray-1);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.list {
+  display: grid;
+  gap: 10px;
 }

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.tsx
@@ -62,8 +62,8 @@ const BridgeHistory = () => {
             <div className={styles.dateGroup} key={date}>
               <div className={styles.dateHeader}>{date}</div>
               <div className={styles.list}>
-                {items.map((tx, index) => (
-                  <AsyncBoundary key={index}>
+                {items.map((tx) => (
+                  <AsyncBoundary key={tx.txHash}>
                     <BridgeHistoryItem tx={tx} />
                   </AsyncBoundary>
                 ))}

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react"
+import { useState, useMemo } from "react"
 import { useToggle } from "usehooks-ts"
 import { useInterwovenKit } from "@/public/data/hooks"
+import { groupByDate } from "@/data/date"
 import Page from "@/components/Page"
 import Status from "@/components/Status"
 import AsyncBoundary from "@/components/AsyncBoundary"
@@ -31,9 +32,18 @@ const BridgeHistory = () => {
   const filteredHistory = showAll ? allHistory : myHistory
   const paginatedHistory = filteredHistory.slice(0, page * BRIDGE_HISTORY_LIMIT_PER_PAGE)
 
+  // Group history items by date
+  const groupedHistory = useMemo(() => {
+    return groupByDate(paginatedHistory, (tx) => {
+      const details = getHistoryDetails(tx)
+      if (!details) return undefined
+      return new Date(details.timestamp)
+    })
+  }, [paginatedHistory, getHistoryDetails])
+
   return (
     <Page title="Bridge/Swap activity">
-      <div className={styles.list}>
+      <div className={styles.history}>
         {allHistory.length > 0 && allHistory.length !== myHistory.length && (
           <header className={styles.header}>
             <CheckboxButton
@@ -48,11 +58,16 @@ const BridgeHistory = () => {
         {filteredHistory.length === 0 ? (
           <Status>No bridge/swap activity</Status>
         ) : (
-          paginatedHistory.map((tx, index) => (
-            <div className={styles.item} key={index}>
-              <AsyncBoundary>
-                <BridgeHistoryItem tx={tx} />
-              </AsyncBoundary>
+          Object.entries(groupedHistory).map(([date, items]) => (
+            <div className={styles.dateGroup} key={date}>
+              <div className={styles.dateHeader}>{date}</div>
+              <div className={styles.list}>
+                {items.map((tx, index) => (
+                  <AsyncBoundary key={index}>
+                    <BridgeHistoryItem tx={tx} />
+                  </AsyncBoundary>
+                ))}
+              </div>
             </div>
           ))
         )}

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeHistoryItem.module.css
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeHistoryItem.module.css
@@ -1,20 +1,20 @@
 .link {
-  width: 100%;
-
   display: flex;
   flex-direction: column;
   align-items: unset;
   gap: 20px;
 
+  background-color: var(--gray-8);
+  border-radius: 8px;
   color: inherit;
   padding: var(--padding);
   padding-top: 16px;
   text-decoration: none;
-
   transition: background-color var(--transition) ease;
+  width: 100%;
 
   &:hover {
-    background-color: var(--gray-8);
+    background-color: var(--gray-7);
     color: inherit;
   }
 }

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeHistoryItem.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeHistoryItem.tsx
@@ -1,5 +1,5 @@
 import { useAccount } from "wagmi"
-import { intlFormatDistance } from "date-fns"
+import { format } from "date-fns"
 import { useEffect, useMemo, type ReactNode } from "react"
 import { IconArrowDown, IconExternalLink, IconWallet } from "@initia/icons-react"
 import { InitiaAddress, formatAmount, truncate } from "@initia/utils"
@@ -110,9 +110,7 @@ const BridgeHistoryItem = ({ tx }: { tx: TxIdentifier }) => {
       <header className={styles.header}>
         <div className={styles.title}>
           {!tracked ? <Loader size={14} /> : <BridgeHistoryItemIcon tx={tx} />}
-          <div className={styles.date}>
-            {intlFormatDistance(new Date(timestamp), new Date(), { locale: "en-US" })}
-          </div>
+          <div className={styles.date}>{format(new Date(timestamp), "h:mm a")}</div>
         </div>
         <div className={styles.explorer}>
           <span>{linkLabel}</span>

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeHistoryItemIcon.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeHistoryItemIcon.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import type { StatusResponseJson } from "@skip-go/client"
-import { IconCheckCircleFilled, IconCloseCircleFilled } from "@initia/icons-react"
+import { IconCloseCircleFilled } from "@initia/icons-react"
 import Loader from "@/components/Loader"
 import { useTxStatusQuery } from "./data/tx"
 import type { TxIdentifier } from "./data/history"
@@ -34,11 +34,7 @@ const BridgeHistoryItemIcon = ({ tx }: { tx: TxIdentifier }) => {
       )
 
     case "success":
-      return (
-        <div className={styles.success}>
-          <IconCheckCircleFilled size={14} />
-        </div>
-      )
+      return null
 
     default:
       return <Loader size={14} />

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/activity/ActivityList.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/activity/ActivityList.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import { useInitiaAddress } from "@/public/data/hooks"
+import { groupByDate } from "@/data/date"
 import Status from "@/components/Status"
 import AsyncBoundary from "@/components/AsyncBoundary"
 import ExplorerLink from "@/components/ExplorerLink"
@@ -12,26 +13,10 @@ const ActivityList = ({ list, chainId }: { list: ChainActivity[]; chainId: strin
 
   // Group activities by date
   const groupedActivities = useMemo(() => {
-    return list.reduce(
-      (groups, activity) => {
-        // Skip activities without timestamp to prevent grouping errors
-        if (!activity.timestamp) return groups
-
-        const date = new Date(activity.timestamp)
-        const dateKey = date.toLocaleDateString("en-US", {
-          month: "short",
-          day: "numeric",
-          year: "numeric",
-        })
-
-        const existingGroup = groups[dateKey] || []
-        return {
-          ...groups,
-          [dateKey]: [...existingGroup, activity],
-        }
-      },
-      {} as Record<string, ChainActivity[]>,
-    )
+    return groupByDate(list, (activity) => {
+      if (!activity.timestamp) return undefined
+      return new Date(activity.timestamp)
+    })
   }, [list])
 
   if (list.length === 0) return <Status>No activity found</Status>


### PR DESCRIPTION
- Add date utility for grouping items by formatted date string
- Update bridge history to display items grouped by date headers
- Replace relative timestamps with time-only format for items
- Apply date grouping to wallet activity list as well
- Improve history item styling with card-like appearance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a reusable date-grouping utility used to group Bridge History and Wallet Activity by calendar date; items without valid dates are omitted.

- UI/Style
  - Redesigned history layout into vertical date groups with clear date headers and improved spacing.
  - Item timestamps now show precise times (e.g., 3:45 PM).
  - List items have full-width clickable areas, rounded corners, subtle backgrounds, and refined hover states.

- Behavior
  - Success state no longer shows a success icon (error and loading states unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->