### PR TITLE
fix(drawer): add onClick handler to backdrop for production builds

### DIFF
--- a/packages/interwovenkit-react/src/public/app/Drawer.tsx
+++ b/packages/interwovenkit-react/src/public/app/Drawer.tsx
@@ -88,7 +88,9 @@ const Drawer = ({ children }: PropsWithChildren) => {
     >
       <Dialog.Portal container={portalContainer}>
         {isSmall && (
-          <Dialog.Backdrop className={styles.overlay}>
+          // This onClick is required for the close functionality to work in production builds.
+          // Without it, closing only works in local dev. Don't remove until thoroughly tested.
+          <Dialog.Backdrop className={styles.overlay} onClick={handleCloseDrawer}>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14" height="14">
               <path d="M7.168 14.04 l 6.028 -6.028 l -6.028 -6.028 L8.57 .582 L16 8.012 l -7.43 7.43 l -1.402 -1.402 Z" />
               <path d="M0.028 14.04 l 6.028 -6.028 L0.028 1.984 L1.43 .582 l 7.43 7.43 l -7.43 7.43 L0.028 14.04 Z" />


### PR DESCRIPTION
- Backdrop now responds to clicks in production environments
- Previously only worked in local development mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * On small screens, tapping the backdrop now reliably closes the drawer in production, improving consistency and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->