### PR TITLE
feat(config): add configurable glyph URL

### DIFF
--- a/packages/interwovenkit-react/src/data/config.ts
+++ b/packages/interwovenkit-react/src/data/config.ts
@@ -11,6 +11,7 @@ export interface Config {
 
   registryUrl: string
   routerApiUrl: string
+  glyphUrl: string
   usernamesModuleAddress: string
 
   theme: "light" | "dark"

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/nft/NftThumbnail.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/nft/NftThumbnail.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx"
+import { useConfig } from "@/data/config"
 import Image from "@/components/Image"
 import type { NftInfo } from "./queries"
 import styles from "./NftThumbnail.module.css"
@@ -11,10 +12,11 @@ interface Props {
 
 const NftThumbnail = ({ nftInfo, size, onClick }: Props) => {
   const { collection_addr, object_addr, nft, chain } = nftInfo
+  const { glyphUrl } = useConfig()
 
   const src = new URL(
     `/v1/${chain.chainId}/${collection_addr}/${object_addr || nft.token_id}`,
-    "https://glyph.initia.xyz",
+    glyphUrl,
   ).toString()
 
   if (onClick) {

--- a/packages/interwovenkit-react/src/public/data/constants.ts
+++ b/packages/interwovenkit-react/src/public/data/constants.ts
@@ -7,6 +7,7 @@ export const MAINNET: Config = {
   defaultChainId: "interwoven-1",
   registryUrl: "https://registry.initia.xyz",
   routerApiUrl: "https://router-api.initia.xyz",
+  glyphUrl: "https://glyph.initia.xyz",
   usernamesModuleAddress: "0x72ed9b26ecdcd6a21d304df50f19abfdbe31d2c02f60c84627844620a45940ef",
   theme: "dark",
 }
@@ -15,6 +16,7 @@ export const TESTNET: Config = {
   defaultChainId: "initiation-2",
   registryUrl: "https://registry.testnet.initia.xyz",
   routerApiUrl: "https://router-api.initiation-2.initia.xyz",
+  glyphUrl: "https://glyph.initiation-2.initia.xyz",
   usernamesModuleAddress: "0x42cd8467b1c86e59bf319e5664a09b6b5840bb3fac64f5ce690b5041c530565a",
   theme: "dark",
   disableAnalytics: true,


### PR DESCRIPTION
- Add glyphUrl field to Config interface
- Update NftThumbnail to use glyphUrl from config
- Set glyph URLs for mainnet and testnet environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - NFT thumbnail images now load from a configurable base URL, enabling environment-specific sources.
  - Added configuration support for glyph URLs in both mainnet and testnet.
- Enhancements
  - Replaced hardcoded NFT image domain with a dynamic value from app settings for greater flexibility and future-proofing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->