### PR TITLE
fix(tx): improve fee balance validation logic

### DIFF
--- a/packages/interwovenkit-react/src/components/form/InputHelp.tsx
+++ b/packages/interwovenkit-react/src/components/form/InputHelp.tsx
@@ -30,7 +30,7 @@ const InputHelp = ({ level, className, mt = 8, children }: PropsWithChildren<Pro
   return (
     <div className={clsx(styles.help, level && styles[level], className)} style={{ marginTop: mt }}>
       <div className={styles.icon}>{getIcon()}</div>
-      <p>{children}</p>
+      {children}
     </div>
   )
 }

--- a/packages/interwovenkit-react/src/pages/tx/TxInsufficientBalance.module.css
+++ b/packages/interwovenkit-react/src/pages/tx/TxInsufficientBalance.module.css
@@ -1,0 +1,78 @@
+.root {
+  flex: 1;
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  width: 100%;
+}
+
+.chevron {
+  transition:
+    transform var(--transition),
+    color var(--transition);
+
+  .trigger:hover & {
+    color: var(--error-light);
+  }
+
+  .trigger[data-state="open"] & {
+    transform: rotate(180deg);
+  }
+}
+
+.content {
+  overflow: hidden;
+
+  &[data-state="open"] {
+    animation: slideDown var(--transition) ease-out;
+  }
+
+  &[data-state="closed"] {
+    animation: slideUp var(--transition) ease-out;
+  }
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  color: var(--error-light);
+  margin-top: 10px;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  :last-child {
+    font-family: var(--monospace);
+  }
+}
+
+@keyframes slideDown {
+  from {
+    height: 0;
+    opacity: 0;
+  }
+  to {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+  }
+}
+
+@keyframes slideUp {
+  from {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+  }
+  to {
+    height: 0;
+    opacity: 0;
+  }
+}

--- a/packages/interwovenkit-react/src/pages/tx/TxInsufficientBalance.tsx
+++ b/packages/interwovenkit-react/src/pages/tx/TxInsufficientBalance.tsx
@@ -1,0 +1,66 @@
+import { Collapsible } from "radix-ui"
+import { IconChevronDown } from "@initia/icons-react"
+import styles from "./TxInsufficientBalance.module.css"
+
+interface TxInsufficientBalanceProps {
+  formattedSpend: string | null
+  formattedFee: string
+  formattedTotal: string
+  formattedBalance: string
+  symbol: string
+}
+
+const TxInsufficientBalance = ({
+  formattedSpend,
+  formattedFee,
+  formattedTotal,
+  formattedBalance,
+  symbol,
+}: TxInsufficientBalanceProps) => {
+  return (
+    <Collapsible.Root defaultOpen={false} className={styles.root}>
+      <Collapsible.Trigger className={styles.trigger}>
+        <span>Insufficient balance for fee</span>
+        <IconChevronDown className={styles.chevron} size={16} />
+      </Collapsible.Trigger>
+
+      <Collapsible.Content className={styles.content}>
+        <div className={styles.details}>
+          {formattedSpend && (
+            <div className={styles.row}>
+              <span>Spend</span>
+              <span>
+                {formattedSpend} {symbol}
+              </span>
+            </div>
+          )}
+
+          <div className={styles.row}>
+            <span>Fee</span>
+            <span>
+              {formattedFee} {symbol}
+            </span>
+          </div>
+
+          {formattedSpend && (
+            <div className={styles.row}>
+              <span>Required (spend + fee)</span>
+              <span>
+                {formattedTotal} {symbol}
+              </span>
+            </div>
+          )}
+
+          <div className={styles.row}>
+            <span>Balance</span>
+            <span>
+              {formattedBalance} {symbol}
+            </span>
+          </div>
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  )
+}
+
+export default TxInsufficientBalance


### PR DESCRIPTION
- Replace p tag with div in InputHelp for nested content support
- Refactor canPayFee into getFeeDetails for detailed validation
- Add formatted amount display with asset decimals
- Include total amount calculation (fee + spend)
- Show balance information in fee selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a collapsible “Insufficient balance for fee” panel showing spend, fee, required total, and balance with formatted amounts and symbols.
  * Automatic fee denomination selection now prefers a sufficient option, reducing failed approvals.

* Refactor
  * Revised fee sufficiency logic and Approve button state to block actions when balance is insufficient.

* Style
  * Introduced smooth expand/collapse animations and clearer error styling for balance details.
  * Simplified form helper text rendering to remove extra paragraph styling for more consistent spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->