### PR TITLE
fix(tx): move fee formatting to component level

### DIFF
--- a/packages/interwovenkit-react/src/pages/tx/TxFeeInsufficient.tsx
+++ b/packages/interwovenkit-react/src/pages/tx/TxFeeInsufficient.tsx
@@ -1,28 +1,30 @@
+import BigNumber from "bignumber.js"
 import { Collapsible } from "@base-ui-components/react/collapsible"
 import { IconChevronDown } from "@initia/icons-react"
+import { formatAmount, fromBaseUnit } from "@initia/utils"
 import styles from "./TxFeeInsufficient.module.css"
 
 interface Props {
-  formattedSpend: string | null
-  formattedFee: string
-  formattedTotal: string
-  formattedBalance: string
+  spend: string | null
+  fee: string
+  total: string
+  balance: string
   symbol: string
+  decimals: number
 }
 
-const TxFeeInsufficient = ({
-  formattedSpend,
-  formattedFee,
-  formattedTotal,
-  formattedBalance,
-  symbol,
-}: Props) => {
+const TxFeeInsufficient = ({ spend, fee, total, balance, symbol, decimals }: Props) => {
   const rows = [
-    formattedSpend && { label: "Spend", value: `${formattedSpend} ${symbol}` },
-    { label: "Fee", value: `${formattedFee} ${symbol}` },
-    formattedSpend && { label: "Required (spend + fee)", value: `${formattedTotal} ${symbol}` },
-    { label: "Balance", value: `${formattedBalance} ${symbol}` },
+    spend && { label: "Spend", value: spend },
+    { label: "Fee", value: fee },
+    spend && { label: "Required (spend + fee)", value: total },
+    { label: "Balance", value: balance },
   ].filter(Boolean) as Array<{ label: string; value: string }>
+
+  // Determine decimal places for display based on fee amount
+  // - decimals=6: use default (undefined)
+  // - otherwise: show up to 8 decimal places if fee would display as 0.000000
+  const dp = BigNumber(fromBaseUnit(fee, { decimals })).lt(0.000001) ? 8 : undefined
 
   return (
     <Collapsible.Root className={styles.root}>
@@ -36,7 +38,9 @@ const TxFeeInsufficient = ({
           {rows.map(({ label, value }) => (
             <div key={label} className={styles.row}>
               <span>{label}</span>
-              <span>{value}</span>
+              <span>
+                {formatAmount(value, { decimals, dp })} {symbol}
+              </span>
             </div>
           ))}
         </div>

--- a/packages/interwovenkit-react/src/pages/tx/TxRequest.tsx
+++ b/packages/interwovenkit-react/src/pages/tx/TxRequest.tsx
@@ -3,7 +3,6 @@ import { sentenceCase } from "change-case"
 import { calculateFee, GasPrice } from "@cosmjs/stargate"
 import { useState } from "react"
 import { useMutation } from "@tanstack/react-query"
-import { formatAmount } from "@initia/utils"
 import { useInitiaAddress } from "@/public/data/hooks"
 import { useBalances } from "@/data/account"
 import { useChain } from "@/data/chains"
@@ -43,28 +42,23 @@ const TxRequest = () => {
   const feeCoins = feeOptions.map((fee) => fee.amount[0])
 
   const getFeeDetails = (feeDenom: string) => {
-    const balance = balances.find((balance) => balance.denom === feeDenom)?.amount ?? 0
-    const feeAmount = feeCoins.find((coin) => coin.denom === feeDenom)?.amount ?? 0
+    const balance = balances.find((balance) => balance.denom === feeDenom)?.amount ?? "0"
+    const feeAmount = feeCoins.find((coin) => coin.denom === feeDenom)?.amount ?? "0"
     const spendAmount = spendCoins
       .filter((coin) => coin.denom === feeDenom)
-      .reduce((total, coin) => BigNumber(total).plus(coin.amount), BigNumber(0))
+      .reduce((total, coin) => BigNumber(total).plus(coin.amount), BigNumber("0"))
     const totalRequired = BigNumber(feeAmount).plus(spendAmount)
     const isSufficient = BigNumber(balance).gte(totalRequired)
 
     const { symbol, decimals } = findAsset(feeDenom)
-    const formattedBalance = formatAmount(balance, { decimals })
-    const formattedFee = formatAmount(feeAmount, { decimals })
-    const formattedSpend = spendAmount.gt(0)
-      ? formatAmount(spendAmount.toFixed(), { decimals })
-      : null
-    const formattedTotal = formatAmount(totalRequired.toFixed(), { decimals })
 
     return {
       symbol,
-      formattedSpend,
-      formattedFee,
-      formattedTotal,
-      formattedBalance,
+      decimals,
+      spend: spendAmount.gt(0) ? spendAmount.toFixed() : null,
+      fee: feeAmount,
+      total: totalRequired.toFixed(),
+      balance,
       isSufficient,
     }
   }


### PR DESCRIPTION
- Pass raw values with decimals from TxRequest to TxFeeInsufficient
- Format amounts in TxFeeInsufficient component
- Add dynamic decimal places based on fee amount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Amounts now auto-format with dynamic decimal precision for clearer readability.
  - Consistent currency symbol appended to spend, fee, total, and balance.
  - “Spend” row is shown only when applicable.

- Bug Fixes
  - Improved display accuracy for very small fees to avoid misleading rounding.

- Refactor
  - Unified amount formatting across transaction fee views for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->