### PR TITLE
Fix/tx fee decimal display

### DIFF
--- a/packages/interwovenkit-react/src/pages/tx/TxFee.tsx
+++ b/packages/interwovenkit-react/src/pages/tx/TxFee.tsx
@@ -21,25 +21,32 @@ const TxFee = ({ options, value, onChange }: Props) => {
   const chain = useChain(txRequest.chainId)
   const findAsset = useFindAsset(chain)
 
+  const getDp = (amount: string, decimals: number) => {
+    if (formatAmount(amount, { decimals }) === "0.000000") return 8
+    return undefined
+  }
+
   const getLabel = ({ amount: [{ amount, denom }] }: StdFee) => {
     if (BigNumber(amount).isZero()) return "0"
     const { symbol, decimals } = findAsset(denom)
-    return `${formatAmount(amount, { decimals })} ${symbol}`
+    const dp = getDp(amount, decimals)
+    return `${formatAmount(amount, { decimals, dp })} ${symbol}`
   }
 
   if (options.length === 1) {
-    return getLabel(options[0])
+    return <span className="monospace">{getLabel(options[0])}</span>
   }
 
   const selected = options.find((o) => o.amount[0].denom === value)
   if (!selected) throw new Error("Fee option not found")
   const [{ amount, denom }] = selected.amount
   const { decimals, symbol } = findAsset(denom)
+  const dp = getDp(amount, decimals)
 
   return (
     <Select.Root value={value} onValueChange={onChange} modal={false}>
       <div className={styles.value}>
-        <span className="monospace">{formatAmount(amount, { decimals })}</span>
+        <span className="monospace">{formatAmount(amount, { decimals, dp })}</span>
         <Select.Trigger className={styles.trigger}>
           <Select.Value>{symbol}</Select.Value>
           <Select.Icon className={styles.icon}>

--- a/packages/interwovenkit-react/src/pages/tx/TxFeeInsufficient.tsx
+++ b/packages/interwovenkit-react/src/pages/tx/TxFeeInsufficient.tsx
@@ -1,7 +1,6 @@
-import BigNumber from "bignumber.js"
 import { Collapsible } from "@base-ui-components/react/collapsible"
 import { IconChevronDown } from "@initia/icons-react"
-import { formatAmount, fromBaseUnit } from "@initia/utils"
+import { formatAmount } from "@initia/utils"
 import styles from "./TxFeeInsufficient.module.css"
 
 interface Props {
@@ -21,10 +20,10 @@ const TxFeeInsufficient = ({ spend, fee, total, balance, symbol, decimals }: Pro
     { label: "Balance", value: balance },
   ].filter(Boolean) as Array<{ label: string; value: string }>
 
-  // Determine decimal places for display based on fee amount
-  // - decimals=6: use default (undefined)
-  // - otherwise: show up to 8 decimal places if fee would display as 0.000000
-  const dp = BigNumber(fromBaseUnit(fee, { decimals })).lt(0.000001) ? 8 : undefined
+  // Show 8 decimal places for high-precision tokens (decimals=18) to display meaningful fee amounts
+  // Without this, fees might show as 0.000000 ETH or required/balance appear equal when they're not
+  // 8dp is a balance between accuracy and UI space constraints (full 18dp would be excessive)
+  const dp = decimals === 6 ? undefined : 8
 
   return (
     <Collapsible.Root className={styles.root}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Fee amounts now auto-adjust precision, showing up to 8 decimal places for very small values to improve readability across tokens.
  - Consistent precision rules applied to selected options and the main displayed fee, including the insufficient funds view.

- Style
  - When only one fee option is available, its label is displayed in monospace for improved legibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->