### PR TITLE
fix: clear in-memory caches on wallet disconnect

### DIFF
--- a/packages/interwovenkit-react/src/data/minity/sse.ts
+++ b/packages/interwovenkit-react/src/data/minity/sse.ts
@@ -1,6 +1,6 @@
-import { useEffect, useEffectEvent } from "react"
+import { useCallback, useEffect, useEffectEvent } from "react"
 import { atom, useAtomValue, useSetAtom } from "jotai"
-import { useQueryClient } from "@tanstack/react-query"
+import { type QueryClient, useQueryClient } from "@tanstack/react-query"
 import { useIsTestnet } from "@/pages/bridge/data/form"
 import { useInitiaAddress } from "@/public/data/hooks"
 import { useConfig } from "../config"
@@ -174,4 +174,25 @@ export function usePortfolioSSE() {
     // minityUrl and queryClient accessed via useEffectEvent handlers (always read latest values)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [address, isTestnet, refreshTrigger])
+}
+
+export function clearSSEPortfolioCache(
+  queryClient: QueryClient,
+  address: string,
+  minityUrl: string,
+) {
+  const queryKey = minityQueryKeys.ssePortfolio(address, minityUrl).queryKey
+  queryClient.removeQueries({ queryKey })
+}
+
+export function useClearSSECache() {
+  const queryClient = useQueryClient()
+  const address = useInitiaAddress()
+  const { minityUrl } = useConfig()
+
+  return useCallback(() => {
+    if (address) {
+      clearSSEPortfolioCache(queryClient, address, minityUrl)
+    }
+  }, [queryClient, address, minityUrl])
 }

--- a/packages/interwovenkit-react/src/data/signer.ts
+++ b/packages/interwovenkit-react/src/data/signer.ts
@@ -262,6 +262,11 @@ export function clearSigningClientCache(address: string, chainId: string) {
   signingStargateClientCache.delete(cacheKey)
 }
 
+export function clearClientCaches() {
+  comet38ClientCache.clear()
+  signingStargateClientCache.clear()
+}
+
 export function useCreateComet38Client() {
   const findChain = useFindChain()
 

--- a/packages/interwovenkit-react/src/data/ui.test.ts
+++ b/packages/interwovenkit-react/src/data/ui.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { LocalStorageKey } from "./constants"
 import { clearDisconnectState } from "./ui"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe("clearDisconnectState", () => {
   it("clears the react query cache alongside the other disconnect state", () => {

--- a/packages/interwovenkit-react/src/data/ui.test.ts
+++ b/packages/interwovenkit-react/src/data/ui.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest"
+import { LocalStorageKey } from "./constants"
+import { clearDisconnectState } from "./ui"
+
+describe("clearDisconnectState", () => {
+  it("clears the react query cache alongside the other disconnect state", () => {
+    const queryClient = { clear: vi.fn() }
+    const clearSSECache = vi.fn()
+    const storage = new Map<string, string>()
+
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+    })
+
+    localStorage.setItem(LocalStorageKey.BRIDGE_SRC_CHAIN_ID, "initia-1")
+    localStorage.setItem(`${LocalStorageKey.PUBLIC_KEY}:init1test`, "abcd")
+
+    clearDisconnectState({
+      queryClient,
+      clearSSECache,
+      address: "init1test",
+    })
+
+    expect(queryClient.clear).toHaveBeenCalledTimes(1)
+    expect(clearSSECache).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem(LocalStorageKey.BRIDGE_SRC_CHAIN_ID)).toBeNull()
+    expect(localStorage.getItem(`${LocalStorageKey.PUBLIC_KEY}:init1test`)).toBeNull()
+  })
+})

--- a/packages/interwovenkit-react/src/data/ui.ts
+++ b/packages/interwovenkit-react/src/data/ui.ts
@@ -1,5 +1,6 @@
 import { useDisconnect as useDisconnectWagmi } from "wagmi"
 import { atom, useAtom, useSetAtom } from "jotai"
+import { type QueryClient, useQueryClient } from "@tanstack/react-query"
 import { useAnalyticsTrack } from "@/data/analytics"
 import { useNavigate, useReset } from "@/lib/router"
 import { useDeriveWallet } from "@/pages/autosign/data/wallet"
@@ -62,11 +63,38 @@ export function useModal() {
   return { isModalOpen: isOpen, openModal: open, closeModal: close }
 }
 
+export function clearDisconnectState({
+  queryClient,
+  clearSSECache,
+  address,
+}: {
+  queryClient: Pick<QueryClient, "clear">
+  clearSSECache: () => void
+  address?: string
+}) {
+  clearClientCaches()
+  clearErrorCache()
+  queryClient.clear()
+  clearSSECache()
+
+  localStorage.removeItem(LocalStorageKey.BRIDGE_SRC_CHAIN_ID)
+  localStorage.removeItem(LocalStorageKey.BRIDGE_SRC_DENOM)
+  localStorage.removeItem(LocalStorageKey.BRIDGE_DST_CHAIN_ID)
+  localStorage.removeItem(LocalStorageKey.BRIDGE_DST_DENOM)
+  localStorage.removeItem(LocalStorageKey.BRIDGE_QUANTITY)
+  localStorage.removeItem(LocalStorageKey.BRIDGE_SLIPPAGE_PERCENT)
+
+  if (address) {
+    localStorage.removeItem(`${LocalStorageKey.PUBLIC_KEY}:${address}`)
+  }
+}
+
 export function useDisconnect() {
   const navigate = useNavigate()
   const { closeDrawer } = useDrawer()
   const { closeModal } = useModal()
   const { disconnect } = useDisconnectWagmi()
+  const queryClient = useQueryClient()
   const { clearAllWallets } = useDeriveWallet()
   const address = useInitiaAddress()
   const clearSSECache = useClearSSECache()
@@ -77,25 +105,10 @@ export function useDisconnect() {
     closeModal()
 
     // Clear all in-memory caches before wallet disconnect
-    clearClientCaches()
-    clearErrorCache()
-    clearSSECache()
+    clearDisconnectState({ queryClient, clearSSECache, address })
 
     disconnect()
 
     clearAllWallets()
-
-    // Clear localStorage values on disconnect
-    localStorage.removeItem(LocalStorageKey.BRIDGE_SRC_CHAIN_ID)
-    localStorage.removeItem(LocalStorageKey.BRIDGE_SRC_DENOM)
-    localStorage.removeItem(LocalStorageKey.BRIDGE_DST_CHAIN_ID)
-    localStorage.removeItem(LocalStorageKey.BRIDGE_DST_DENOM)
-    localStorage.removeItem(LocalStorageKey.BRIDGE_QUANTITY)
-    localStorage.removeItem(LocalStorageKey.BRIDGE_SLIPPAGE_PERCENT)
-
-    // Clear cached public key for current address
-    if (address) {
-      localStorage.removeItem(`${LocalStorageKey.PUBLIC_KEY}:${address}`)
-    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Modifies wallet disconnect behavior to aggressively clear multiple in-memory caches (React Query, signer RPC clients, SSE portfolio queries), which could cause unexpected data refetching or state loss if invoked in the wrong context.
> 
> **Overview**
> On wallet disconnect, the widget now clears **all in-memory caches** before calling the wallet provider: React Query cache (`queryClient.clear()`), signer client caches, Move error registry cache, and Minity SSE portfolio query data.
> 
> This extracts the cleanup into a reusable `clearDisconnectState` helper (also removing the stored derived public key for the current address) and adds `useClearSSECache`/`clearSSEPortfolioCache` utilities plus a unit test asserting both cache and localStorage cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ae5a6044ace3cda8479f2f5c0ce71126e6fcbe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive cache-clearing utilities, including SSE-specific and consolidated client cache clearing.
  * Enhanced disconnect flow to clear all cached data and bridge-related stored keys, improving reconnection reliability.

* **Tests**
  * Added test coverage verifying coordinated cache and local-storage cleanup during disconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->