### PR TITLE
Sign-in wallet prioritization logic

### DIFF
--- a/packages/interwovenkit-react/src/pages/connect/SignIn.tsx
+++ b/packages/interwovenkit-react/src/pages/connect/SignIn.tsx
@@ -5,6 +5,7 @@ import Image from "@/components/Image"
 import Loader from "@/components/Loader"
 import Scrollable from "@/components/Scrollable"
 import { normalizeWalletName } from "./normalizeWalletName"
+import { prioritizeSignInWallets } from "./prioritizeSignInWallets"
 import styles from "./Connect.module.css"
 
 const MoreDotsIcon = () => (
@@ -90,6 +91,8 @@ const POPULAR_WALLETS = [
   },
 ]
 
+const SIGN_IN_WALLET_LIMIT = 5
+
 interface Props {
   walletConnectors: Connector[]
   privyConnector: Connector | undefined
@@ -112,13 +115,17 @@ const SignIn = ({
   onPrefetchWallets,
 }: Props) => {
   const readyConnectors = walletConnectors.filter((c) => !("ready" in c) || Boolean(c.ready))
-  const suggestedWallets = readyConnectors.slice(0, 5)
+  const suggestedWallets = prioritizeSignInWallets(
+    readyConnectors,
+    POPULAR_WALLETS,
+    SIGN_IN_WALLET_LIMIT,
+  )
   const readyConnectorIds = new Set(readyConnectors.map((c) => c.id))
   const readyConnectorNamesNormalized = new Set(
     readyConnectors.map((c) => normalizeWalletName(c.name)),
   )
 
-  const slotsToFill = Math.max(0, 5 - suggestedWallets.length)
+  const slotsToFill = Math.max(0, SIGN_IN_WALLET_LIMIT - suggestedWallets.length)
   const popularToShow = POPULAR_WALLETS.filter(
     (w) =>
       !readyConnectorIds.has(w.id) &&

--- a/packages/interwovenkit-react/src/pages/connect/SignIn.tsx
+++ b/packages/interwovenkit-react/src/pages/connect/SignIn.tsx
@@ -173,7 +173,7 @@ const SignIn = ({
       <Scrollable className={styles.scrollable}>
         <div className={styles.list}>
           {suggestedWallets.map((connector) => {
-            const { name, icon, id } = connector
+            const { icon, id, name, uid } = connector
             const isPendingConnection = pendingConnectorId === id
             const isRecent = recentConnectorId === id
 
@@ -184,7 +184,7 @@ const SignIn = ({
                 onClick={() => onConnect(connector)}
                 disabled={isPending}
                 aria-busy={isPendingConnection}
-                key={id}
+                key={uid}
               >
                 <div className={styles.listIconWrapper}>
                   <Image src={icon} width={26} height={26} alt="" className={styles.icon} />

--- a/packages/interwovenkit-react/src/pages/connect/SignIn.tsx
+++ b/packages/interwovenkit-react/src/pages/connect/SignIn.tsx
@@ -119,6 +119,7 @@ const SignIn = ({
     readyConnectors,
     POPULAR_WALLETS,
     SIGN_IN_WALLET_LIMIT,
+    recentConnectorId,
   )
   const readyConnectorIds = new Set(readyConnectors.map((c) => c.id))
   const readyConnectorNamesNormalized = new Set(

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { prioritizeSignInWallets } from "./prioritizeSignInWallets"
+
+interface WalletLike {
+  id: string
+  name: string
+}
+
+const POPULAR_WALLETS: WalletLike[] = [
+  { id: "io.rabby", name: "Rabby" },
+  { id: "app.phantom", name: "Phantom" },
+  { id: "app.keplr", name: "Keplr" },
+  { id: "io.leapwallet", name: "Leap" },
+  { id: "io.metamask", name: "MetaMask" },
+]
+
+describe("prioritizeSignInWallets", () => {
+  it("keeps original order when wallet count is within limit", () => {
+    const readyWallets: WalletLike[] = [
+      { id: "wallet.alpha", name: "Alpha" },
+      { id: "wallet.beta", name: "Beta" },
+      { id: "io.metamask", name: "MetaMask" },
+    ]
+
+    const result = prioritizeSignInWallets(readyWallets, POPULAR_WALLETS, 5)
+
+    expect(result).toEqual(readyWallets)
+  })
+
+  it("prioritizes owned popular wallets first when over limit", () => {
+    const readyWallets: WalletLike[] = [
+      { id: "wallet.alpha", name: "Alpha" },
+      { id: "wallet.beta", name: "Beta" },
+      { id: "io.metamask", name: "MetaMask" },
+      { id: "wallet.gamma", name: "Gamma" },
+      { id: "app.keplr", name: "Keplr" },
+      { id: "wallet.delta", name: "Delta" },
+    ]
+
+    const result = prioritizeSignInWallets(readyWallets, POPULAR_WALLETS, 5)
+
+    expect(result.map((wallet) => wallet.id)).toEqual([
+      "io.metamask",
+      "app.keplr",
+      "wallet.alpha",
+      "wallet.beta",
+      "wallet.gamma",
+    ])
+  })
+
+  it("matches popular wallets by normalized name", () => {
+    const readyWallets: WalletLike[] = [
+      { id: "wallet.alpha", name: "Alpha" },
+      { id: "wallet.beta", name: "Beta" },
+      { id: "wallet.custom.leap", name: "Leap Wallet" },
+      { id: "wallet.gamma", name: "Gamma" },
+      { id: "wallet.delta", name: "Delta" },
+      { id: "wallet.epsilon", name: "Epsilon" },
+    ]
+
+    const result = prioritizeSignInWallets(readyWallets, POPULAR_WALLETS, 5)
+
+    expect(result.map((wallet) => wallet.id)).toEqual([
+      "wallet.custom.leap",
+      "wallet.alpha",
+      "wallet.beta",
+      "wallet.gamma",
+      "wallet.delta",
+    ])
+  })
+})

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { prioritizeSignInWallets } from "./prioritizeSignInWallets"
-
-interface WalletLike {
-  id: string
-  name: string
-}
+import { prioritizeSignInWallets, type WalletLike } from "./prioritizeSignInWallets"
 
 const POPULAR_WALLETS: WalletLike[] = [
   { id: "io.rabby", name: "Rabby" },

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
@@ -142,4 +142,25 @@ describe("prioritizeSignInWallets", () => {
       "wallet.gamma",
     ])
   })
+
+  it("removes only one recent wallet when duplicate ids exist", () => {
+    const readyWallets: WalletLike[] = [
+      { id: "wallet.duplicate", name: "Duplicate One" },
+      { id: "wallet.alpha", name: "Alpha" },
+      { id: "wallet.duplicate", name: "Duplicate Two" },
+      { id: "io.metamask", name: "MetaMask" },
+      { id: "wallet.beta", name: "Beta" },
+      { id: "wallet.gamma", name: "Gamma" },
+    ]
+
+    const result = prioritizeSignInWallets(readyWallets, POPULAR_WALLETS, 5, "wallet.duplicate")
+
+    expect(result.map((wallet) => wallet.name)).toEqual([
+      "Duplicate One",
+      "MetaMask",
+      "Alpha",
+      "Duplicate Two",
+      "Beta",
+    ])
+  })
 })

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
@@ -68,4 +68,25 @@ describe("prioritizeSignInWallets", () => {
       "wallet.delta",
     ])
   })
+
+  it("keeps the recent wallet visible even when five popular wallets are installed", () => {
+    const readyWallets: WalletLike[] = [
+      { id: "wallet.recent", name: "Recent Wallet" },
+      { id: "io.rabby", name: "Rabby" },
+      { id: "app.phantom", name: "Phantom" },
+      { id: "app.keplr", name: "Keplr" },
+      { id: "io.leapwallet", name: "Leap" },
+      { id: "io.metamask", name: "MetaMask" },
+    ]
+
+    const result = prioritizeSignInWallets(readyWallets, POPULAR_WALLETS, 5, "wallet.recent")
+
+    expect(result.map((wallet) => wallet.id)).toEqual([
+      "wallet.recent",
+      "io.rabby",
+      "app.phantom",
+      "app.keplr",
+      "io.leapwallet",
+    ])
+  })
 })

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.test.ts
@@ -15,6 +15,17 @@ const POPULAR_WALLETS: WalletLike[] = [
 ]
 
 describe("prioritizeSignInWallets", () => {
+  it("returns an empty list when the limit is zero or negative", () => {
+    const readyWallets: WalletLike[] = [{ id: "wallet.alpha", name: "Alpha" }]
+
+    expect(prioritizeSignInWallets(readyWallets, POPULAR_WALLETS, 0)).toEqual([])
+    expect(prioritizeSignInWallets(readyWallets, POPULAR_WALLETS, -1)).toEqual([])
+  })
+
+  it("returns an empty list when no wallets are ready", () => {
+    expect(prioritizeSignInWallets([], POPULAR_WALLETS, 5)).toEqual([])
+  })
+
   it("keeps original order when wallet count is within limit", () => {
     const readyWallets: WalletLike[] = [
       { id: "wallet.alpha", name: "Alpha" },
@@ -69,6 +80,27 @@ describe("prioritizeSignInWallets", () => {
     ])
   })
 
+  it("ignores a recent wallet id that is not present", () => {
+    const readyWallets: WalletLike[] = [
+      { id: "wallet.alpha", name: "Alpha" },
+      { id: "wallet.beta", name: "Beta" },
+      { id: "io.metamask", name: "MetaMask" },
+      { id: "wallet.gamma", name: "Gamma" },
+      { id: "wallet.delta", name: "Delta" },
+      { id: "wallet.epsilon", name: "Epsilon" },
+    ]
+
+    const result = prioritizeSignInWallets(readyWallets, POPULAR_WALLETS, 5, "wallet.missing")
+
+    expect(result.map((wallet) => wallet.id)).toEqual([
+      "io.metamask",
+      "wallet.alpha",
+      "wallet.beta",
+      "wallet.gamma",
+      "wallet.delta",
+    ])
+  })
+
   it("keeps the recent wallet visible even when five popular wallets are installed", () => {
     const readyWallets: WalletLike[] = [
       { id: "wallet.recent", name: "Recent Wallet" },
@@ -87,6 +119,27 @@ describe("prioritizeSignInWallets", () => {
       "app.phantom",
       "app.keplr",
       "io.leapwallet",
+    ])
+  })
+
+  it("keeps a recent popular wallet in the first slot", () => {
+    const readyWallets: WalletLike[] = [
+      { id: "wallet.alpha", name: "Alpha" },
+      { id: "io.metamask", name: "MetaMask" },
+      { id: "app.keplr", name: "Keplr" },
+      { id: "wallet.beta", name: "Beta" },
+      { id: "wallet.gamma", name: "Gamma" },
+      { id: "wallet.delta", name: "Delta" },
+    ]
+
+    const result = prioritizeSignInWallets(readyWallets, POPULAR_WALLETS, 5, "io.metamask")
+
+    expect(result.map((wallet) => wallet.id)).toEqual([
+      "io.metamask",
+      "app.keplr",
+      "wallet.alpha",
+      "wallet.beta",
+      "wallet.gamma",
     ])
   })
 })

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
@@ -1,0 +1,37 @@
+import { normalizeWalletName } from "./normalizeWalletName"
+
+interface WalletLike {
+  id: string
+  name: string
+}
+
+export const prioritizeSignInWallets = <T extends WalletLike>(
+  readyWallets: readonly T[],
+  popularWallets: readonly WalletLike[],
+  limit: number,
+): T[] => {
+  if (limit <= 0) return []
+  if (readyWallets.length <= limit) return [...readyWallets]
+
+  const popularIds = new Set(popularWallets.map((wallet) => wallet.id))
+  const popularNamesNormalized = new Set(
+    popularWallets.map((wallet) => normalizeWalletName(wallet.name)),
+  )
+
+  const prioritized: T[] = []
+  const remaining: T[] = []
+
+  for (const wallet of readyWallets) {
+    const isPopular =
+      popularIds.has(wallet.id) ||
+      popularNamesNormalized.has(normalizeWalletName(wallet.name))
+
+    if (isPopular) {
+      prioritized.push(wallet)
+    } else {
+      remaining.push(wallet)
+    }
+  }
+
+  return prioritized.concat(remaining).slice(0, limit)
+}

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
@@ -23,8 +23,7 @@ export const prioritizeSignInWallets = <T extends WalletLike>(
 
   for (const wallet of readyWallets) {
     const isPopular =
-      popularIds.has(wallet.id) ||
-      popularNamesNormalized.has(normalizeWalletName(wallet.name))
+      popularIds.has(wallet.id) || popularNamesNormalized.has(normalizeWalletName(wallet.name))
 
     if (isPopular) {
       prioritized.push(wallet)

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
@@ -14,12 +14,14 @@ export const prioritizeSignInWallets = <T extends WalletLike>(
   if (limit <= 0) return []
   if (readyWallets.length <= limit) return [...readyWallets]
 
-  const recentWallet = recentWalletId
-    ? readyWallets.find((wallet) => wallet.id === recentWalletId)
-    : undefined
-  const walletsToPrioritize = recentWallet
-    ? readyWallets.filter((wallet) => wallet.id !== recentWallet.id)
-    : readyWallets
+  const recentWalletIndex = recentWalletId
+    ? readyWallets.findIndex((wallet) => wallet.id === recentWalletId)
+    : -1
+  const recentWallet = recentWalletIndex >= 0 ? readyWallets[recentWalletIndex] : undefined
+  const walletsToPrioritize =
+    recentWalletIndex >= 0
+      ? readyWallets.filter((_, index) => index !== recentWalletIndex)
+      : readyWallets
 
   // Match by exact id when possible. Normalized-name matching is only a
   // fallback for variants like "Leap Wallet", and can still collide.

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
@@ -9,9 +9,17 @@ export const prioritizeSignInWallets = <T extends WalletLike>(
   readyWallets: readonly T[],
   popularWallets: readonly WalletLike[],
   limit: number,
+  recentWalletId?: string | null,
 ): T[] => {
   if (limit <= 0) return []
   if (readyWallets.length <= limit) return [...readyWallets]
+
+  const recentWallet = recentWalletId
+    ? readyWallets.find((wallet) => wallet.id === recentWalletId)
+    : undefined
+  const walletsToPrioritize = recentWallet
+    ? readyWallets.filter((wallet) => wallet.id !== recentWallet.id)
+    : readyWallets
 
   const popularIds = new Set(popularWallets.map((wallet) => wallet.id))
   const popularNamesNormalized = new Set(
@@ -21,7 +29,7 @@ export const prioritizeSignInWallets = <T extends WalletLike>(
   const prioritized: T[] = []
   const remaining: T[] = []
 
-  for (const wallet of readyWallets) {
+  for (const wallet of walletsToPrioritize) {
     const isPopular =
       popularIds.has(wallet.id) || popularNamesNormalized.has(normalizeWalletName(wallet.name))
 
@@ -32,5 +40,7 @@ export const prioritizeSignInWallets = <T extends WalletLike>(
     }
   }
 
-  return prioritized.concat(remaining).slice(0, limit)
+  return recentWallet
+    ? [recentWallet, ...prioritized, ...remaining].slice(0, limit)
+    : prioritized.concat(remaining).slice(0, limit)
 }

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
@@ -21,6 +21,8 @@ export const prioritizeSignInWallets = <T extends WalletLike>(
     ? readyWallets.filter((wallet) => wallet.id !== recentWallet.id)
     : readyWallets
 
+  // Match by exact id when possible. Normalized-name matching is only a
+  // fallback for variants like "Leap Wallet", and can still collide.
   const popularIds = new Set(popularWallets.map((wallet) => wallet.id))
   const popularNamesNormalized = new Set(
     popularWallets.map((wallet) => normalizeWalletName(wallet.name)),

--- a/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
+++ b/packages/interwovenkit-react/src/pages/connect/prioritizeSignInWallets.ts
@@ -1,6 +1,6 @@
 import { normalizeWalletName } from "./normalizeWalletName"
 
-interface WalletLike {
+export interface WalletLike {
   id: string
   name: string
 }


### PR DESCRIPTION
Prioritize owned popular wallets in sign-in suggestions when the number of ready wallets exceeds the display limit.

This ensures that users with many installed wallets see their popular ones (e.g., MetaMask, Rabby) first in the limited 5-slot display on the sign-in page, improving discoverability without reordering when within the limit.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ac2892b8-fb48-44da-a973-19b71cd13aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac2892b8-fb48-44da-a973-19b71cd13aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet ordering logic on the sign-in page and switches list keys to `uid`, which could affect rendering stability and which wallets are surfaced to users when many connectors are available.
> 
> **Overview**
> Improves the sign-in wallet suggestions so the 5-slot list surfaces the user’s **recent wallet first** (when present) and then prioritizes **installed popular wallets** (matched by id, with normalized-name fallback) before filling with the remaining ready wallets.
> 
> Introduces `prioritizeSignInWallets` with dedicated Vitest coverage for limits, popular matching, recent handling, and duplicate ids, and updates `SignIn.tsx` to use this helper (including centralizing the display limit and using connector `uid` as the React list key).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a95efe68ff00d45f0cfb47cbc9c2f6f371d98a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced wallet selection on the sign-in screen: up to five suggested wallets are now intelligently prioritized to surface popular matches first and ensure a recently used wallet remains visible, improving discoverability and streamlining connections.

* **Tests**
  * Added comprehensive tests for prioritization: limit enforcement, popular-wallet detection (including name variants), recent-wallet handling, ordering rules, and duplicate-id behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->