### PR TITLE
Rename Interwoven Economy to Apps in bridge chain selector

### DIFF
--- a/packages/interwovenkit-react/src/pages/bridge/SelectChainAsset.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/SelectChainAsset.tsx
@@ -51,7 +51,7 @@ const SelectChainAsset = ({ type, afterSelect }: Props) => {
     <>
       <ChainOptions.Stack>
         <ChainOptions
-          label="Interwoven Economy"
+          label="Apps"
           chains={internalChains.map(({ chain_id, chain_name, pretty_name, logo_uri }) => {
             return { chainId: chain_id, name: pretty_name || chain_name, logoUrl: logo_uri ?? "" }
           })}


### PR DESCRIPTION
### Motivation
- Update UI terminology to match product guidance by renaming the bridge chain group label from "Interwoven Economy" to "Apps".

### Description
- Replace the label string in `packages/interwovenkit-react/src/pages/bridge/SelectChainAsset.tsx` so the internal chain group now displays as `Apps`, which applies to both source and destination selection flows.

### Testing
- Ran `pnpm -C packages/interwovenkit-react typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9fda1f2a08333a711a664190f27f7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only terminology change that updates a displayed label string without affecting bridge logic or data handling.
> 
> **Overview**
> Updates the bridge chain selector UI by renaming the internal chain group label from **"Interwoven Economy"** to **"Apps"** in `SelectChainAsset.tsx`, affecting both source and destination selection flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4330a673fea9afd67d2c5fa0a7a283741e42482d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated label text in the chain asset selector interface for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->