### PR TITLE
fix(assets): resolve metadata to denom locally

### DIFF
--- a/packages/interwovenkit-react/src/data/assets.test.ts
+++ b/packages/interwovenkit-react/src/data/assets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { metadataToDenom } from "./assets"
+import { createMetadataDenomsMap, metadataToDenom } from "./assets"
 
 describe("metadataToDenom", () => {
   it("converts a full-length metadata address", () => {
@@ -18,5 +18,15 @@ describe("metadataToDenom", () => {
     expect(metadataToDenom("0x87e5481f8b5fe116ebc1c2b3ee523d86e3640e5f")).toBe(
       "move/00000000000000000000000087e5481f8b5fe116ebc1c2b3ee523d86e3640e5f",
     )
+  })
+})
+
+describe("createMetadataDenomsMap", () => {
+  it("skips malformed metadata values instead of throwing", () => {
+    const result = createMetadataDenomsMap(["0x1", "invalid"])
+
+    expect(Array.from(result.entries())).toEqual([
+      ["0x1", "move/0000000000000000000000000000000000000000000000000000000000000001"],
+    ])
   })
 })

--- a/packages/interwovenkit-react/src/data/assets.test.ts
+++ b/packages/interwovenkit-react/src/data/assets.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { metadataToDenom } from "./assets"
+
+describe("metadataToDenom", () => {
+  it("converts a full-length metadata address", () => {
+    expect(
+      metadataToDenom("0x8009f4738c51127e82a2f298d4a687bb85e4138ceee150a4bd3b6e4735d666d1"),
+    ).toBe("move/8009f4738c51127e82a2f298d4a687bb85e4138ceee150a4bd3b6e4735d666d1")
+  })
+
+  it("pads short metadata addresses to 64 hex chars", () => {
+    expect(metadataToDenom("0x1")).toBe(
+      "move/0000000000000000000000000000000000000000000000000000000000000001",
+    )
+  })
+
+  it("converts a medium-length metadata address with leading zeros stripped", () => {
+    expect(metadataToDenom("0x87e5481f8b5fe116ebc1c2b3ee523d86e3640e5f")).toBe(
+      "move/00000000000000000000000087e5481f8b5fe116ebc1c2b3ee523d86e3640e5f",
+    )
+  })
+})

--- a/packages/interwovenkit-react/src/data/assets.ts
+++ b/packages/interwovenkit-react/src/data/assets.ts
@@ -142,13 +142,22 @@ export function metadataToDenom(metadata: string): string {
   return `move/${InitiaAddress(metadata, 32).rawHex}`
 }
 
+export function createMetadataDenomsMap(metadatas: string[]) {
+  return metadatas.reduce((map, metadata) => {
+    try {
+      map.set(metadata, metadataToDenom(metadata))
+    } catch {
+      // Skip malformed metadata so one bad value does not crash the whole hook.
+    }
+
+    return map
+  }, new Map<string, string>())
+}
+
 /**
  * Resolves metadata addresses to denoms locally without API calls.
  * Returns a Map of metadata -> denom.
  */
 export function useDenoms(metadatas: string[]) {
-  return useMemo(
-    () => new Map(metadatas.map((metadata) => [metadata, metadataToDenom(metadata)])),
-    [metadatas],
-  )
+  return useMemo(() => createMetadataDenomsMap(metadatas), [metadatas])
 }

--- a/packages/interwovenkit-react/src/data/assets.ts
+++ b/packages/interwovenkit-react/src/data/assets.ts
@@ -1,15 +1,10 @@
 import ky from "ky"
 import { head } from "ramda"
-import {
-  queryOptions,
-  useQueries,
-  useQueryClient,
-  useSuspenseQueries,
-  useSuspenseQuery,
-} from "@tanstack/react-query"
+import { useMemo } from "react"
+import { queryOptions, useQueries, useQueryClient, useSuspenseQuery } from "@tanstack/react-query"
 import { createQueryKeys } from "@lukemorales/query-key-factory"
 import type { Asset, AssetList } from "@initia/initia-registry-types"
-import { getIbcDenom } from "@initia/utils"
+import { getIbcDenom, InitiaAddress } from "@initia/utils"
 import type { BaseAsset } from "@/components/form/types"
 import type { NormalizedChain } from "./chains"
 import { useInitiaRegistry, useLayer1 } from "./chains"
@@ -140,36 +135,20 @@ export function useGetLayer1Denom(chain: NormalizedChain) {
 }
 
 /**
- * Fetches denom from metadata addresses using the Move denom API.
+ * Converts a Move metadata address to its denom locally.
+ * For hex metadata, the denom is `move/` + zero-padded 64-char hex.
+ */
+export function metadataToDenom(metadata: string): string {
+  return `move/${InitiaAddress(metadata, 32).rawHex}`
+}
+
+/**
+ * Resolves metadata addresses to denoms locally without API calls.
  * Returns a Map of metadata -> denom.
  */
-export function useDenoms(
-  metadatas: string[],
-  options?: {
-    failSoft?: boolean
-  },
-) {
-  const layer1 = useLayer1()
-  const restClient = ky.create({ prefixUrl: layer1.restUrl })
-  const failSoft = options?.failSoft ?? false
-
-  const result = useSuspenseQueries({
-    queries: metadatas.map((metadata) => ({
-      queryFn: async () => {
-        try {
-          return await restClient
-            .get("initia/move/v1/denom", { searchParams: { metadata } })
-            .json<{ denom: string }>()
-        } catch (error) {
-          if (failSoft) return { denom: "" }
-          throw error
-        }
-      },
-      queryKey: [...assetQueryKeys.denom(layer1.restUrl, metadata).queryKey, failSoft],
-      select: (data: { denom: string }): [string, string] => [metadata, data.denom],
-      staleTime: STALE_TIMES.INFINITY,
-    })),
-  })
-
-  return new Map(result.map(({ data }) => data!))
+export function useDenoms(metadatas: string[]) {
+  return useMemo(
+    () => new Map(metadatas.map((metadata) => [metadata, metadataToDenom(metadata)])),
+    [metadatas],
+  )
 }

--- a/packages/interwovenkit-react/src/data/initia-liquidity.ts
+++ b/packages/interwovenkit-react/src/data/initia-liquidity.ts
@@ -372,7 +372,7 @@ export function useInitiaLiquidityPositions(): LiquiditySectionData {
 
     return Array.from(metadatas)
   }, [clammPositions])
-  const clammRewardMetadataToDenom = useDenoms(clammRewardMetadataList, { failSoft: true })
+  const clammRewardMetadataToDenom = useDenoms(clammRewardMetadataList)
 
   const allMetadataKeys = useMemo(
     () => collectMetadataKeys(lps, delegations, lockStaking, undelegations),

--- a/packages/interwovenkit-react/src/pages/tx/TxSimulate.tsx
+++ b/packages/interwovenkit-react/src/pages/tx/TxSimulate.tsx
@@ -62,7 +62,7 @@ const ChangesWithMetadata = ({
 
   return changes.map(({ amount, metadata }, index) => {
     return (
-      <WithDenom metadata={metadata} chain={chain} key={index}>
+      <WithDenom metadata={metadata} key={index}>
         {(denom) => {
           const price = prices?.find(({ id }) => id === denom)?.price
           return <Change amount={amount} asset={findAsset(denom)} price={price} />

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/activity/ActivityChanges.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/activity/ActivityChanges.tsx
@@ -45,7 +45,7 @@ const ChangesWithMetadata = ({
 
   return changes.map(({ amount, metadata }, index) => {
     return (
-      <WithDenom metadata={metadata} chain={chain} key={index}>
+      <WithDenom metadata={metadata} key={index}>
         {(denom) => <Change amount={amount} asset={findAsset(denom)} />}
       </WithDenom>
     )

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/activity/WithDenom.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/activity/WithDenom.tsx
@@ -1,32 +1,14 @@
-import ky from "ky"
-import { useSuspenseQuery } from "@tanstack/react-query"
-import { assetQueryKeys } from "@/data/assets"
-import type { NormalizedChain } from "@/data/chains"
-import { STALE_TIMES } from "@/data/http"
+import { metadataToDenom } from "@/data/assets"
 
 import type { ReactNode } from "react"
 
 interface Props {
   metadata: string
-  chain: NormalizedChain
   children: (denom: string) => ReactNode
 }
 
-const WithDenom = ({ metadata, chain, children }: Props) => {
-  const { restUrl } = chain
-
-  const { data: denom } = useSuspenseQuery({
-    queryKey: assetQueryKeys.denom(restUrl, metadata).queryKey,
-    queryFn: () =>
-      ky
-        .create({ prefixUrl: restUrl })
-        .get("initia/move/v1/denom", { searchParams: { metadata } })
-        .json<{ denom: string }>(),
-    select: ({ denom }) => denom,
-    staleTime: STALE_TIMES.INFINITY,
-  })
-
-  return children(denom)
+const WithDenom = ({ metadata, children }: Props) => {
+  return children(metadataToDenom(metadata))
 }
 
 export default WithDenom

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/activity/WithDenom.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/activity/WithDenom.tsx
@@ -8,7 +8,15 @@ interface Props {
 }
 
 const WithDenom = ({ metadata, children }: Props) => {
-  return children(metadataToDenom(metadata))
+  let denom: string
+
+  try {
+    denom = metadataToDenom(metadata)
+  } catch {
+    return null
+  }
+
+  return children(denom)
 }
 
 export default WithDenom


### PR DESCRIPTION
## Summary
- replace metadata-to-denom API lookups with a local `metadataToDenom` helper based on `InitiaAddress`
- remove the suspense queries from `useDenoms` and `WithDenom`
- add unit coverage for short, medium, and full-length metadata inputs

## Why
The Move metadata to denom mapping is deterministic for move assets: the denom is `move/` plus the zero-padded 32-byte hex form of the metadata address. Fetching `initia/move/v1/denom` for every metadata value added unnecessary N+1 network requests in activity, tx simulation, and liquidity paths even though the result can be computed locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how metadata→denom resolution works across liquidity, activity, and tx simulation flows, removing network-backed lookups; incorrect local conversion or edge-case metadata handling could lead to missing/incorrect asset display.
> 
> **Overview**
> **Replaces Move metadata→denom API lookups with deterministic local conversion.** Adds `metadataToDenom` (via `InitiaAddress` zero-padding) plus `createMetadataDenomsMap`, and rewrites `useDenoms` to memoize a local map instead of running suspense queries.
> 
> **Removes chain/rest-based denom fetching in UI paths.** `WithDenom` no longer depends on `chain` or React Query/`ky`, and callers in activity + tx simulation are updated accordingly; liquidity reward metadata resolution drops the prior soft-fail option.
> 
> Adds unit tests covering short/medium/full metadata inputs and ensuring malformed metadata values are skipped rather than throwing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8aaf90e1ad7877facb4aa0be472eb1de86741f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Denomination resolution now runs entirely locally and synchronously, reducing network calls and improving responsiveness.
  * Components no longer perform remote denom lookups; malformed metadata are skipped safely and prior soft-fallback behavior was removed.
  * Minor render call sites simplified to rely on local denom resolution.

* **Tests**
  * New tests validate deterministic metadata→denom conversions for various lengths and ensure malformed entries are ignored without throwing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->