### PR TITLE
fix(bridge): derive skip assets from cached data

### DIFF
--- a/packages/interwovenkit-react/src/pages/bridge/data/assets.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/assets.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+import { type RouterAsset, sortSkipAssets } from "./assets"
+
+describe("sortSkipAssets", () => {
+  it("keeps INIT first when filtering a chain-local asset list", () => {
+    const assets: RouterAsset[] = [
+      {
+        chain_id: "interwoven-1",
+        denom: "uusdc",
+        symbol: "USDC",
+        decimals: 6,
+        origin_denom: "uusdc",
+        origin_chain_id: "interwoven-1",
+        trace: "",
+        is_cw20: false,
+        is_evm: false,
+        is_svm: false,
+      },
+      {
+        chain_id: "interwoven-1",
+        denom: "uinit",
+        symbol: "INIT",
+        decimals: 6,
+        origin_denom: "uinit",
+        origin_chain_id: "interwoven-1",
+        trace: "",
+        is_cw20: false,
+        is_evm: false,
+        is_svm: false,
+      },
+      {
+        chain_id: "interwoven-1",
+        denom: "uatom",
+        symbol: "ATOM",
+        decimals: 6,
+        origin_denom: "uatom",
+        origin_chain_id: "interwoven-1",
+        trace: "",
+        is_cw20: false,
+        is_evm: false,
+        is_svm: false,
+      },
+    ]
+
+    expect(sortSkipAssets(assets).map((asset) => asset.symbol)).toEqual(["INIT", "USDC", "ATOM"])
+  })
+})

--- a/packages/interwovenkit-react/src/pages/bridge/data/assets.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/assets.test.ts
@@ -1,47 +1,43 @@
 import { describe, expect, it } from "vitest"
 import { type RouterAsset, sortSkipAssets } from "./assets"
 
+function createAsset(symbol: string, denom = symbol.toLowerCase()): RouterAsset {
+  return {
+    chain_id: "interwoven-1",
+    denom,
+    symbol,
+    decimals: 6,
+    origin_denom: denom,
+    origin_chain_id: "interwoven-1",
+    trace: "",
+    is_cw20: false,
+    is_evm: false,
+    is_svm: false,
+  }
+}
+
 describe("sortSkipAssets", () => {
-  it("keeps INIT first when filtering a chain-local asset list", () => {
+  it("keeps INIT first when sorting a chain-local asset list", () => {
     const assets: RouterAsset[] = [
-      {
-        chain_id: "interwoven-1",
-        denom: "uusdc",
-        symbol: "USDC",
-        decimals: 6,
-        origin_denom: "uusdc",
-        origin_chain_id: "interwoven-1",
-        trace: "",
-        is_cw20: false,
-        is_evm: false,
-        is_svm: false,
-      },
-      {
-        chain_id: "interwoven-1",
-        denom: "uinit",
-        symbol: "INIT",
-        decimals: 6,
-        origin_denom: "uinit",
-        origin_chain_id: "interwoven-1",
-        trace: "",
-        is_cw20: false,
-        is_evm: false,
-        is_svm: false,
-      },
-      {
-        chain_id: "interwoven-1",
-        denom: "uatom",
-        symbol: "ATOM",
-        decimals: 6,
-        origin_denom: "uatom",
-        origin_chain_id: "interwoven-1",
-        trace: "",
-        is_cw20: false,
-        is_evm: false,
-        is_svm: false,
-      },
+      createAsset("USDC", "uusdc"),
+      createAsset("INIT", "uinit"),
+      createAsset("ATOM", "uatom"),
     ]
 
     expect(sortSkipAssets(assets).map((asset) => asset.symbol)).toEqual(["INIT", "USDC", "ATOM"])
+  })
+
+  it("returns an empty array for empty input", () => {
+    expect(sortSkipAssets([])).toEqual([])
+  })
+
+  it("preserves the relative order of non-INIT assets", () => {
+    const assets: RouterAsset[] = [
+      createAsset("USDC", "uusdc"),
+      createAsset("ATOM", "uatom"),
+      createAsset("OSMO", "uosmo"),
+    ]
+
+    expect(sortSkipAssets(assets).map((asset) => asset.symbol)).toEqual(["USDC", "ATOM", "OSMO"])
   })
 })

--- a/packages/interwovenkit-react/src/pages/bridge/data/assets.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/assets.ts
@@ -17,6 +17,10 @@ export type AllAssetsResponse = {
   chain_to_assets_map: Partial<Record<string, { assets: RouterAsset[] }>>
 }
 
+export function sortSkipAssets(assets: RouterAsset[]) {
+  return assets.toSorted(descend((asset) => asset.symbol === "INIT"))
+}
+
 /** Fetch all assets without chains dependency so prefetch can run parallel to chains fetch */
 export function useAllSkipAssetsRaw() {
   const skip = useSkip()
@@ -55,24 +59,11 @@ export function useAllSkipAssets() {
 }
 
 export function useSkipAssets(chainId: string) {
-  const skip = useSkip()
-  const queryClient = useQueryClient()
-  const { data } = useSuspenseQuery({
-    queryKey: skipQueryKeys.assets(chainId).queryKey,
-    queryFn: () =>
-      skip
-        .get("v2/fungible/assets", { searchParams: { chain_ids: chainId } })
-        .json<{ chain_to_assets_map: Partial<Record<string, { assets: RouterAsset[] }>> }>(),
-    select: ({ chain_to_assets_map }) => {
-      const { assets } = chain_to_assets_map[chainId] ?? { assets: [] }
-      for (const asset of assets) {
-        queryClient.setQueryData(skipQueryKeys.asset(chainId, asset.denom).queryKey, asset)
-      }
-      return assets.toSorted(descend((asset) => asset.symbol === "INIT"))
-    },
-    staleTime: STALE_TIMES.MINUTE,
-  })
-  return data
+  const assets = useAllSkipAssets()
+  return useMemo(
+    () => sortSkipAssets(assets.filter((asset) => asset.chain_id === chainId)),
+    [assets, chainId],
+  )
 }
 
 export function useFindSkipAsset(chainId: string) {

--- a/packages/interwovenkit-react/src/pages/bridge/data/assets.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/assets.ts
@@ -18,7 +18,7 @@ export type AllAssetsResponse = {
 }
 
 export function sortSkipAssets(assets: RouterAsset[]) {
-  return assets.toSorted(descend((asset) => asset.symbol === "INIT"))
+  return assets.slice().sort(descend((asset) => asset.symbol === "INIT"))
 }
 
 /** Fetch all assets without chains dependency so prefetch can run parallel to chains fetch */


### PR DESCRIPTION
## Summary
- remove the per-chain Skip asset fetch path from the bridge asset hooks
- derive `useSkipAssets` locally from the already-cached full Skip asset payload
- add focused coverage for the chain-local sorting behavior

## Why
The provider already prefetches the full `v2/fungible/assets` response and `useAllSkipAssets` seeds per-chain and per-asset cache entries from that payload. `useSkipAssets` was still making an additional `v2/fungible/assets?chain_ids=...` request for each chain selection even though the same data was already available locally. This change removes those redundant requests while preserving the existing `INIT`-first ordering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes redundant per-chain fetches and changes sorting to a shared helper; main risk is subtle differences in asset ordering/filtering affecting bridge dropdowns.
> 
> **Overview**
> `useSkipAssets` no longer issues a per-chain `v2/fungible/assets?chain_ids=...` request; it now derives the chain’s asset list by filtering the already-cached `useAllSkipAssets` result.
> 
> Asset ordering is centralized in a new `sortSkipAssets` helper to keep `INIT` first, and new Vitest coverage verifies `INIT` prioritization, empty-input behavior, and stable ordering for non-`INIT` assets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f7cc4cd10ffb079bd1f3608624a603f79b3f34b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying asset sorting: prioritizes the INIT symbol, preserves original order for other assets, and handles empty inputs.

* **Refactors**
  * Centralized and simplified asset retrieval and sorting so per-chain queries are replaced by a derived, memoized filter of the global asset set for more consistent and efficient results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->