### PR TITLE
fix: show deposit fee warning for gas-token max

### DIFF
--- a/packages/interwovenkit-react/src/pages/bridge/BridgePreviewFooter.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgePreviewFooter.tsx
@@ -15,6 +15,7 @@ interface Props {
   onCompleted?: (result: BridgeTxResult) => void
   confirmMessage?: string
   error?: string
+  warning?: string
   isCheckingApprovals?: boolean
   isCheckingFeeBalance?: boolean
   messageRefreshError?: string
@@ -25,19 +26,24 @@ interface Props {
 
 function getStatusMessage({
   error,
+  warning,
   messageRefreshError,
   refreshError,
   requiresReconfirm,
 }: {
   error?: string
+  warning?: string
   messageRefreshError?: string
   refreshError?: string
   requiresReconfirm?: boolean
-}): string | undefined {
-  if (error) return error
-  if (messageRefreshError) return messageRefreshError
-  if (refreshError) return refreshError
-  if (requiresReconfirm) return "Route updated. Please review and confirm again."
+}): { level: "error" | "warning" | "info"; text: string } | undefined {
+  if (error) return { level: "error", text: error }
+  if (messageRefreshError) return { level: "error", text: messageRefreshError }
+  if (refreshError) return { level: "error", text: refreshError }
+  if (warning) return { level: "warning", text: warning }
+  if (requiresReconfirm) {
+    return { level: "info", text: "Route updated. Please review and confirm again." }
+  }
 }
 
 function getBackgroundLoadingText({
@@ -81,6 +87,7 @@ const BridgePreviewFooter = ({
   onCompleted,
   confirmMessage,
   error,
+  warning,
   isCheckingApprovals,
   isCheckingFeeBalance,
   messageRefreshError,
@@ -131,6 +138,7 @@ const BridgePreviewFooter = ({
 
   const statusMessage = getStatusMessage({
     error,
+    warning,
     messageRefreshError,
     refreshError,
     requiresReconfirm,
@@ -140,15 +148,13 @@ const BridgePreviewFooter = ({
 
   return (
     <Footer
-      extra={
-        statusMessage && (
-          <FormHelp level={error || messageRefreshError || refreshError ? "error" : "info"}>
-            {statusMessage}
-          </FormHelp>
-        )
-      }
+      extra={statusMessage && <FormHelp level={statusMessage.level}>{statusMessage.text}</FormHelp>}
     >
-      <Button.White onClick={onConfirm} loading={loadingText} disabled={!!error || isBusy}>
+      <Button.White
+        onClick={onConfirm}
+        loading={loadingText}
+        disabled={!!error || !!warning || isBusy}
+      >
         {getBridgeConfirmLabel(confirmMessage, Boolean(requiresReconfirm))}
       </Button.White>
     </Footer>

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFooter.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFooter.tsx
@@ -177,8 +177,8 @@ const TransferFooterWithFee = ({
       fee={selectedFee}
       onCompleted={onCompleted}
       confirmMessage={confirmMessage}
-      error={feeWarning ? undefined : balanceError}
-      warning={feeWarning}
+      error={feeWarning && feeDenom === srcDenom ? undefined : balanceError}
+      warning={feeDenom === srcDenom ? feeWarning : undefined}
       {...loadingStateProps}
     />
   )

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFooter.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFooter.tsx
@@ -15,6 +15,7 @@ import { useAllSkipAssets } from "../bridge/data/assets"
 import { type BridgeTxResult, useBridgePreviewState } from "../bridge/data/tx"
 import FooterWithErc20Approval from "../bridge/FooterWithErc20Approval"
 import { type TransferMode, useTransferForm } from "./hooks"
+import { getTransferFeeWarning } from "./transferFeeWarning"
 import TransferTxDetails from "./TransferTxDetails"
 import styles from "./TransferFooter.module.css"
 
@@ -164,8 +165,11 @@ const TransferFooterWithFee = ({
 
   const selectedFee = feeDenom ? feeOptionsByDenom.get(feeDenom) : undefined
 
-  // Check if balance is sufficient for both fee and transfer amount
   const feeDetails = feeDenom ? feeDetailsByDenom.get(feeDenom) : null
+  const feeWarning = getTransferFeeWarning({
+    sourceDenom: srcDenom,
+    feeDetailsByDenom,
+  })
   const balanceError = feeDetails && !feeDetails.isSufficient ? "Insufficient balance" : undefined
   const footer = (
     <BridgePreviewFooter
@@ -173,7 +177,8 @@ const TransferFooterWithFee = ({
       fee={selectedFee}
       onCompleted={onCompleted}
       confirmMessage={confirmMessage}
-      error={balanceError}
+      error={feeWarning ? undefined : balanceError}
+      warning={feeWarning}
       {...loadingStateProps}
     />
   )

--- a/packages/interwovenkit-react/src/pages/deposit/transferFeeWarning.test.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferFeeWarning.test.ts
@@ -1,0 +1,42 @@
+import { getTransferFeeWarning } from "./transferFeeWarning"
+
+describe("getTransferFeeWarning", () => {
+  it("warns when the source gas token cannot cover both spend and fee", () => {
+    expect(
+      getTransferFeeWarning({
+        sourceDenom: "uinit",
+        feeDetailsByDenom: new Map([["uinit", { isSufficient: false }]]),
+      }),
+    ).toBe("Make sure to leave enough for transaction fee")
+  })
+
+  it("does not warn when the source denom is not used for fees", () => {
+    expect(
+      getTransferFeeWarning({
+        sourceDenom: "uinit",
+        feeDetailsByDenom: new Map([["uusdc", { isSufficient: false }]]),
+      }),
+    ).toBeUndefined()
+  })
+
+  it("does not warn when another fee denom remains available", () => {
+    expect(
+      getTransferFeeWarning({
+        sourceDenom: "uinit",
+        feeDetailsByDenom: new Map([
+          ["uinit", { isSufficient: false }],
+          ["uusdc", { isSufficient: true }],
+        ]),
+      }),
+    ).toBeUndefined()
+  })
+
+  it("does not warn when the source denom still has enough balance", () => {
+    expect(
+      getTransferFeeWarning({
+        sourceDenom: "uinit",
+        feeDetailsByDenom: new Map([["uinit", { isSufficient: true }]]),
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/packages/interwovenkit-react/src/pages/deposit/transferFeeWarning.test.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferFeeWarning.test.ts
@@ -1,11 +1,23 @@
 import { getTransferFeeWarning } from "./transferFeeWarning"
 
+function createFeeDetails({
+  balance = "1000",
+  fee = "500",
+  isSufficient,
+}: {
+  balance?: string
+  fee?: string
+  isSufficient: boolean
+}) {
+  return { balance, fee, isSufficient }
+}
+
 describe("getTransferFeeWarning", () => {
   it("warns when the source gas token cannot cover both spend and fee", () => {
     expect(
       getTransferFeeWarning({
         sourceDenom: "uinit",
-        feeDetailsByDenom: new Map([["uinit", { isSufficient: false }]]),
+        feeDetailsByDenom: new Map([["uinit", createFeeDetails({ isSufficient: false })]]),
       }),
     ).toBe("Make sure to leave enough for transaction fee")
   })
@@ -14,7 +26,7 @@ describe("getTransferFeeWarning", () => {
     expect(
       getTransferFeeWarning({
         sourceDenom: "uinit",
-        feeDetailsByDenom: new Map([["uusdc", { isSufficient: false }]]),
+        feeDetailsByDenom: new Map([["uusdc", createFeeDetails({ isSufficient: false })]]),
       }),
     ).toBeUndefined()
   })
@@ -24,8 +36,19 @@ describe("getTransferFeeWarning", () => {
       getTransferFeeWarning({
         sourceDenom: "uinit",
         feeDetailsByDenom: new Map([
-          ["uinit", { isSufficient: false }],
-          ["uusdc", { isSufficient: true }],
+          ["uinit", createFeeDetails({ isSufficient: false })],
+          ["uusdc", createFeeDetails({ isSufficient: true })],
+        ]),
+      }),
+    ).toBeUndefined()
+  })
+
+  it("does not warn when the wallet cannot cover the source fee at all", () => {
+    expect(
+      getTransferFeeWarning({
+        sourceDenom: "uinit",
+        feeDetailsByDenom: new Map([
+          ["uinit", createFeeDetails({ balance: "499", isSufficient: false })],
         ]),
       }),
     ).toBeUndefined()
@@ -35,7 +58,7 @@ describe("getTransferFeeWarning", () => {
     expect(
       getTransferFeeWarning({
         sourceDenom: "uinit",
-        feeDetailsByDenom: new Map([["uinit", { isSufficient: true }]]),
+        feeDetailsByDenom: new Map([["uinit", createFeeDetails({ isSufficient: true })]]),
       }),
     ).toBeUndefined()
   })

--- a/packages/interwovenkit-react/src/pages/deposit/transferFeeWarning.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferFeeWarning.ts
@@ -1,0 +1,23 @@
+interface FeeDetails {
+  isSufficient: boolean
+}
+
+interface Params {
+  sourceDenom: string
+  feeDetailsByDenom: Map<string, FeeDetails>
+}
+
+export function getTransferFeeWarning({
+  sourceDenom,
+  feeDetailsByDenom,
+}: Params): string | undefined {
+  const sourceFee = feeDetailsByDenom.get(sourceDenom)
+  if (!sourceFee || sourceFee.isSufficient) return
+
+  const hasAlternativeFeeBalance = Array.from(feeDetailsByDenom.entries()).some(
+    ([denom, feeDetails]) => denom !== sourceDenom && feeDetails.isSufficient,
+  )
+  if (hasAlternativeFeeBalance) return
+
+  return "Make sure to leave enough for transaction fee"
+}

--- a/packages/interwovenkit-react/src/pages/deposit/transferFeeWarning.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferFeeWarning.ts
@@ -1,4 +1,8 @@
+import BigNumber from "bignumber.js"
+
 interface FeeDetails {
+  balance: string
+  fee: string
   isSufficient: boolean
 }
 
@@ -14,10 +18,12 @@ export function getTransferFeeWarning({
   const sourceFee = feeDetailsByDenom.get(sourceDenom)
   if (!sourceFee || sourceFee.isSufficient) return
 
-  const hasAlternativeFeeBalance = Array.from(feeDetailsByDenom.entries()).some(
-    ([denom, feeDetails]) => denom !== sourceDenom && feeDetails.isSufficient,
-  )
-  if (hasAlternativeFeeBalance) return
+  for (const [denom, feeDetails] of feeDetailsByDenom) {
+    if (denom !== sourceDenom && feeDetails.isSufficient) return
+  }
+
+  const canCoverFeeWithoutSpendingSource = BigNumber(sourceFee.balance).gte(sourceFee.fee)
+  if (!canCoverFeeWithoutSpendingSource) return
 
   return "Make sure to leave enough for transaction fee"
 }


### PR DESCRIPTION
This fixes the deposit preview state when the user selects MAX on a source asset that is also used to pay gas.

In the deposit flow, MAX fills the full source balance. When that source denom is also the active fee token and no alternative fee token can cover the transaction fee, the preview was collapsing that situation into a generic insufficient-balance error. The dedicated fee warning never surfaced, so the UI did not explain that the amount only became invalid because no balance was left for gas.

The change adds a small deposit-specific helper to detect that case from the selected source denom and the computed fee sufficiency map. Deposit preview now passes a warning state into the shared preview footer so the user sees a specific message telling them to leave enough for transaction fee, while still preventing confirmation for an amount that cannot be executed. The shared footer now supports warning-level copy without changing the existing error and refresh flows used elsewhere.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation gating and status messaging in the shared `BridgePreviewFooter`, which affects multiple flows; logic is straightforward but could block confirmations if warning conditions are mis-triggered.
> 
> **Overview**
> Deposit/transfer preview now distinguishes a *fee-related “leave enough for gas”* situation from a generic insufficient-balance error when the source asset is also the selected fee token.
> 
> `BridgePreviewFooter` adds a `warning` prop and upgrades status rendering to return `{level,text}` so the footer can show **warning vs error vs info** messaging and disables confirm when a warning is present.
> 
> A new `getTransferFeeWarning` helper (with unit tests) detects the “MAX on gas token leaves no fee” case and `TransferFooter` wires it to pass `warning` (and suppress `error`) when applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eecfafacd84ab691306bca5f2898edf38d99541f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warning-level status messages in footers.
  * Added transfer fee warning detection to alert when transaction fees may be insufficient.

* **Improvements**
  * Confirm button now disables for warnings as well as errors.
  * Status messages support error, warning, and info levels for clearer feedback; fee warnings suppress conflicting balance errors when relevant.

* **Tests**
  * Added tests covering transfer fee warning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->