### PR TITLE
fix: disable withdraw when balance is zero

### DIFF
--- a/packages/interwovenkit-react/src/pages/deposit/Fields.module.css
+++ b/packages/interwovenkit-react/src/pages/deposit/Fields.module.css
@@ -139,17 +139,6 @@
   font-weight: 600;
 }
 
-.balanceLabel {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-
-  color: var(--gray-3);
-  font-family: var(--monospace);
-  font-size: 12px;
-  font-weight: 500;
-}
-
 .detail {
   display: flex;
   justify-content: space-between;

--- a/packages/interwovenkit-react/src/pages/deposit/Fields.module.css
+++ b/packages/interwovenkit-react/src/pages/deposit/Fields.module.css
@@ -139,6 +139,17 @@
   font-weight: 600;
 }
 
+.balanceLabel {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  color: var(--gray-3);
+  font-family: var(--monospace);
+  font-size: 12px;
+  font-weight: 500;
+}
+
 .detail {
   display: flex;
   justify-content: space-between;

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
@@ -334,24 +334,30 @@ const TransferFields = ({ mode }: Props) => {
     <>
       <p className={styles.label}>Amount</p>
       <QuantityInput balance={balance} decimals={amountDecimals} className={styles.input} />
-      {Number(balance) > 0 && (
+      {balance !== undefined && (
         <div className={styles.balanceContainer}>
           <p className={styles.value}>
             {rawQuantity ? formatValueWithPrice(quantityValue.toString(), price) : "$-"}
           </p>
 
-          <button
-            className={styles.maxButton}
-            onClick={() => {
-              const maxAmount = fromBaseUnit(balance ?? "0", { decimals: amountDecimals })
-              if (BigNumber(rawQuantity || 0).eq(maxAmount)) return
+          {BigNumber(balance).gt(0) ? (
+            <button
+              className={styles.maxButton}
+              onClick={() => {
+                const maxAmount = fromBaseUnit(balance, { decimals: amountDecimals })
+                if (BigNumber(rawQuantity || 0).eq(maxAmount)) return
 
-              setValue("quantity", maxAmount)
-            }}
-          >
-            <IconWallet size={16} /> {formatAmount(balance, { decimals: amountDecimals })}{" "}
-            <span>MAX</span>
-          </button>
+                setValue("quantity", maxAmount)
+              }}
+            >
+              <IconWallet size={16} /> {formatAmount(balance, { decimals: amountDecimals })}{" "}
+              <span>MAX</span>
+            </button>
+          ) : (
+            <p className={styles.balanceLabel}>
+              <IconWallet size={16} /> {formatAmount(balance, { decimals: amountDecimals })}
+            </p>
+          )}
         </div>
       )}
     </>

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
@@ -157,6 +157,8 @@ const TransferFields = ({ mode }: Props) => {
     hasBalanceQueryError: !!(balancesError || chainsError),
     isBalancesLoading,
   })
+  // Once balances have loaded, a missing denom means zero balance.
+  // Keep `undefined` only while the first snapshot is still loading.
   const balance = getResolvedTransferBalance({
     hasBalancesSnapshot: balances !== undefined,
     balance: sourceBalance,

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
@@ -29,7 +29,7 @@ import {
   useTransferMode,
 } from "./hooks"
 import { buildTransferLocationState, type TransferLocationState } from "./state"
-import { getTransferBalanceBlocker } from "./transferBalanceGate"
+import { getResolvedTransferBalance, getTransferBalanceBlocker } from "./transferBalanceGate"
 import TransferFooter from "./TransferFooter"
 import { shouldSyncTransferNavigationState } from "./transferNavigationState"
 import styles from "./Fields.module.css"
@@ -144,7 +144,7 @@ const TransferFields = ({ mode }: Props) => {
     : ""
   const externalChain = selectedExternalChainId ? findChain(selectedExternalChainId) : null
 
-  const balance = balances?.[srcChainId]?.[srcDenom]?.amount
+  const sourceBalance = balances?.[srcChainId]?.[srcDenom]?.amount
   const price = balances?.[srcChainId]?.[srcDenom]?.price
 
   const quantityValue = BigNumber(price ?? 0).times(rawQuantity || 0)
@@ -156,6 +156,10 @@ const TransferFields = ({ mode }: Props) => {
     hasBalancesSnapshot: balances !== undefined,
     hasBalanceQueryError: !!(balancesError || chainsError),
     isBalancesLoading,
+  })
+  const balance = getResolvedTransferBalance({
+    hasBalancesSnapshot: balances !== undefined,
+    balance: sourceBalance,
   })
 
   const disabledMessage = useMemo(() => {
@@ -169,8 +173,6 @@ const TransferFields = ({ mode }: Props) => {
     if (balanceBlocker === "loading") return "Loading balances..."
     if (balanceBlocker === "error") return "Failed to load balances"
 
-    // Skip validation when balance is unavailable (e.g. still loading)
-    // to avoid disabling the button with "Insufficient balance" prematurely.
     if (balance !== undefined) {
       const balanceAmount = fromBaseUnit(balance, { decimals: amountAsset?.decimals || 6 })
       if (quantityBn.gt(balanceAmount)) return "Insufficient balance"
@@ -185,8 +187,6 @@ const TransferFields = ({ mode }: Props) => {
     if (mode === "withdraw" && !externalAsset) return true
     if (balanceBlocker === "error") return true
 
-    // Allow route fetching to start while balances load. Once a balance exists,
-    // still block invalid over-balance requests from hitting the route API.
     if (balance !== undefined) {
       const balanceAmount = fromBaseUnit(balance, { decimals: amountAsset?.decimals || 6 })
       if (quantityBn.gt(balanceAmount)) return true

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
@@ -340,24 +340,18 @@ const TransferFields = ({ mode }: Props) => {
             {rawQuantity ? formatValueWithPrice(quantityValue.toString(), price) : "$-"}
           </p>
 
-          {BigNumber(balance).gt(0) ? (
-            <button
-              className={styles.maxButton}
-              onClick={() => {
-                const maxAmount = fromBaseUnit(balance, { decimals: amountDecimals })
-                if (BigNumber(rawQuantity || 0).eq(maxAmount)) return
+          <button
+            className={styles.maxButton}
+            onClick={() => {
+              const maxAmount = fromBaseUnit(balance, { decimals: amountDecimals })
+              if (BigNumber(rawQuantity || 0).eq(maxAmount)) return
 
-                setValue("quantity", maxAmount)
-              }}
-            >
-              <IconWallet size={16} /> {formatAmount(balance, { decimals: amountDecimals })}{" "}
-              <span>MAX</span>
-            </button>
-          ) : (
-            <p className={styles.balanceLabel}>
-              <IconWallet size={16} /> {formatAmount(balance, { decimals: amountDecimals })}
-            </p>
-          )}
+              setValue("quantity", maxAmount)
+            }}
+          >
+            <IconWallet size={16} /> {formatAmount(balance, { decimals: amountDecimals })}{" "}
+            <span>MAX</span>
+          </button>
         </div>
       )}
     </>

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFooter.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFooter.tsx
@@ -17,6 +17,7 @@ import FooterWithErc20Approval from "../bridge/FooterWithErc20Approval"
 import { type TransferMode, useTransferForm } from "./hooks"
 import { hasSufficientTransferBalance } from "./transferBalanceGate"
 import { getTransferFeeWarning } from "./transferFeeWarning"
+import { getTransferFooterStatus } from "./transferFooterState"
 import TransferTxDetails from "./TransferTxDetails"
 import styles from "./TransferFooter.module.css"
 
@@ -75,6 +76,7 @@ function selectFeeDenom({
 
   return feeOptions[0]?.amount[0].denom
 }
+
 interface FooterWithFeeProps extends Omit<Props, "gas" | "mode"> {
   gas: number | null
   confirmMessage: "Deposit" | "Withdraw"
@@ -171,21 +173,24 @@ const TransferFooterWithFee = ({
     feeDetailsByDenom,
   })
   const hasSourceBalance = hasSufficientTransferBalance({
-    balance: balancesByDenom.get(srcDenom) ?? "0",
+    balance: balancesByDenom.get(srcDenom) ?? "0", // suspense boundary ensures balances are loaded; missing denom means zero
     requiredAmount: sourceSpendAmount,
   })
-  const balanceError =
-    !hasSourceBalance || (feeDetails && !feeDetails.isSufficient)
-      ? "Insufficient balance"
-      : undefined
+  const footerStatus = getTransferFooterStatus({
+    feeDenom,
+    sourceDenom: srcDenom,
+    feeWarning,
+    hasSourceBalance,
+    isFeeBalanceSufficient: feeDetails?.isSufficient ?? true,
+  })
   const footer = (
     <BridgePreviewFooter
       tx={tx}
       fee={selectedFee}
       onCompleted={onCompleted}
       confirmMessage={confirmMessage}
-      error={feeWarning && feeDenom === srcDenom ? undefined : balanceError}
-      warning={feeDenom === srcDenom ? feeWarning : undefined}
+      error={footerStatus.error}
+      warning={footerStatus.warning}
       {...loadingStateProps}
     />
   )

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFooter.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFooter.tsx
@@ -15,6 +15,7 @@ import { useAllSkipAssets } from "../bridge/data/assets"
 import { type BridgeTxResult, useBridgePreviewState } from "../bridge/data/tx"
 import FooterWithErc20Approval from "../bridge/FooterWithErc20Approval"
 import { type TransferMode, useTransferForm } from "./hooks"
+import { hasSufficientTransferBalance } from "./transferBalanceGate"
 import { getTransferFeeWarning } from "./transferFeeWarning"
 import TransferTxDetails from "./TransferTxDetails"
 import styles from "./TransferFooter.module.css"
@@ -74,7 +75,6 @@ function selectFeeDenom({
 
   return feeOptions[0]?.amount[0].denom
 }
-
 interface FooterWithFeeProps extends Omit<Props, "gas" | "mode"> {
   gas: number | null
   confirmMessage: "Deposit" | "Withdraw"
@@ -170,7 +170,14 @@ const TransferFooterWithFee = ({
     sourceDenom: srcDenom,
     feeDetailsByDenom,
   })
-  const balanceError = feeDetails && !feeDetails.isSufficient ? "Insufficient balance" : undefined
+  const hasSourceBalance = hasSufficientTransferBalance({
+    balance: balancesByDenom.get(srcDenom) ?? "0",
+    requiredAmount: sourceSpendAmount,
+  })
+  const balanceError =
+    !hasSourceBalance || (feeDetails && !feeDetails.isSufficient)
+      ? "Insufficient balance"
+      : undefined
   const footer = (
     <BridgePreviewFooter
       tx={tx}

--- a/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.test.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.test.ts
@@ -65,6 +65,15 @@ describe("hasSufficientTransferBalance", () => {
     ).toBe(true)
   })
 
+  it("returns true when balance exactly equals required amount", () => {
+    expect(
+      hasSufficientTransferBalance({
+        balance: "100",
+        requiredAmount: "100",
+      }),
+    ).toBe(true)
+  })
+
   it("treats a missing balance as zero when checking a positive spend amount", () => {
     expect(
       hasSufficientTransferBalance({

--- a/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.test.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.test.ts
@@ -27,6 +27,15 @@ describe("getTransferBalanceBlocker", () => {
 })
 
 describe("getResolvedTransferBalance", () => {
+  it("returns the provided balance once balances have loaded", () => {
+    expect(
+      getResolvedTransferBalance({
+        hasBalancesSnapshot: true,
+        balance: "123",
+      }),
+    ).toBe("123")
+  })
+
   it("treats a missing balance as zero after balances have loaded", () => {
     expect(
       getResolvedTransferBalance({
@@ -47,7 +56,25 @@ describe("getResolvedTransferBalance", () => {
 })
 
 describe("hasSufficientTransferBalance", () => {
+  it("returns true when the balance covers the required amount", () => {
+    expect(
+      hasSufficientTransferBalance({
+        balance: "2",
+        requiredAmount: "1",
+      }),
+    ).toBe(true)
+  })
+
   it("treats a missing balance as zero when checking a positive spend amount", () => {
+    expect(
+      hasSufficientTransferBalance({
+        balance: undefined,
+        requiredAmount: "1",
+      }),
+    ).toBe(false)
+  })
+
+  it("returns false when a zero balance cannot cover a positive spend amount", () => {
     expect(
       hasSufficientTransferBalance({
         balance: "0",
@@ -63,5 +90,20 @@ describe("hasSufficientTransferBalance", () => {
         requiredAmount: "0",
       }),
     ).toBe(true)
+  })
+
+  it("returns false for invalid numeric inputs", () => {
+    expect(
+      hasSufficientTransferBalance({
+        balance: "",
+        requiredAmount: "1",
+      }),
+    ).toBe(false)
+    expect(
+      hasSufficientTransferBalance({
+        balance: "1",
+        requiredAmount: "-1",
+      }),
+    ).toBe(false)
   })
 })

--- a/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.test.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.test.ts
@@ -1,4 +1,8 @@
-import { getTransferBalanceBlocker } from "./transferBalanceGate"
+import {
+  getResolvedTransferBalance,
+  getTransferBalanceBlocker,
+  hasSufficientTransferBalance,
+} from "./transferBalanceGate"
 
 describe("getTransferBalanceBlocker", () => {
   it("does not block when cached balances survive a refetch error", () => {
@@ -19,5 +23,45 @@ describe("getTransferBalanceBlocker", () => {
         isBalancesLoading: false,
       }),
     ).toBe("error")
+  })
+})
+
+describe("getResolvedTransferBalance", () => {
+  it("treats a missing balance as zero after balances have loaded", () => {
+    expect(
+      getResolvedTransferBalance({
+        hasBalancesSnapshot: true,
+        balance: undefined,
+      }),
+    ).toBe("0")
+  })
+
+  it("keeps balance undefined while the first balance snapshot is still loading", () => {
+    expect(
+      getResolvedTransferBalance({
+        hasBalancesSnapshot: false,
+        balance: undefined,
+      }),
+    ).toBeUndefined()
+  })
+})
+
+describe("hasSufficientTransferBalance", () => {
+  it("treats a missing balance as zero when checking a positive spend amount", () => {
+    expect(
+      hasSufficientTransferBalance({
+        balance: "0",
+        requiredAmount: "1",
+      }),
+    ).toBe(false)
+  })
+
+  it("accepts a zero spend amount", () => {
+    expect(
+      hasSufficientTransferBalance({
+        balance: "0",
+        requiredAmount: "0",
+      }),
+    ).toBe(true)
   })
 })

--- a/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.ts
@@ -1,3 +1,5 @@
+import BigNumber from "bignumber.js"
+
 export type TransferBalanceBlocker = "loading" | "error" | undefined
 
 interface GetTransferBalanceBlockerArgs {
@@ -14,4 +16,29 @@ export function getTransferBalanceBlocker({
   if (hasBalancesSnapshot) return undefined
   if (isBalancesLoading) return "loading"
   if (hasBalanceQueryError) return "error"
+}
+
+interface GetResolvedTransferBalanceArgs {
+  hasBalancesSnapshot: boolean
+  balance?: string
+}
+
+export function getResolvedTransferBalance({
+  hasBalancesSnapshot,
+  balance,
+}: GetResolvedTransferBalanceArgs): string | undefined {
+  if (!hasBalancesSnapshot) return undefined
+  return balance ?? "0"
+}
+
+interface HasSufficientTransferBalanceArgs {
+  balance?: string
+  requiredAmount: string
+}
+
+export function hasSufficientTransferBalance({
+  balance,
+  requiredAmount,
+}: HasSufficientTransferBalanceArgs): boolean {
+  return requiredAmount === "0" || BigNumber(balance ?? "0").gte(requiredAmount)
 }

--- a/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.ts
@@ -40,7 +40,7 @@ function getNonNegativeAmount(value: string): BigNumber | null {
   if (!value) return null
 
   const amount = BigNumber(value)
-  if (!amount.isFinite() || amount.isNaN() || amount.lt(0)) return null
+  if (!amount.isFinite() || amount.lt(0)) return null
 
   return amount
 }

--- a/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferBalanceGate.ts
@@ -36,9 +36,25 @@ interface HasSufficientTransferBalanceArgs {
   requiredAmount: string
 }
 
+function getNonNegativeAmount(value: string): BigNumber | null {
+  if (!value) return null
+
+  const amount = BigNumber(value)
+  if (!amount.isFinite() || amount.isNaN() || amount.lt(0)) return null
+
+  return amount
+}
+
 export function hasSufficientTransferBalance({
   balance,
   requiredAmount,
 }: HasSufficientTransferBalanceArgs): boolean {
-  return requiredAmount === "0" || BigNumber(balance ?? "0").gte(requiredAmount)
+  if (requiredAmount === "0") return true
+
+  const available = getNonNegativeAmount(balance ?? "0")
+  const required = getNonNegativeAmount(requiredAmount)
+
+  if (!available || !required) return false
+
+  return available.gte(required)
 }

--- a/packages/interwovenkit-react/src/pages/deposit/transferFooterState.test.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferFooterState.test.ts
@@ -24,4 +24,26 @@ describe("getTransferFooterStatus", () => {
       }),
     ).toEqual({ warning: "Make sure to leave enough for transaction fee" })
   })
+
+  it("shows insufficient balance when the fee cannot be covered and there is no warning", () => {
+    expect(
+      getTransferFooterStatus({
+        feeDenom: "uusdc",
+        sourceDenom: "uinit",
+        hasSourceBalance: true,
+        isFeeBalanceSufficient: false,
+      }),
+    ).toEqual({ error: "Insufficient balance" })
+  })
+
+  it("returns an empty status when both transfer amount and fee are covered", () => {
+    expect(
+      getTransferFooterStatus({
+        feeDenom: "uusdc",
+        sourceDenom: "uinit",
+        hasSourceBalance: true,
+        isFeeBalanceSufficient: true,
+      }),
+    ).toEqual({})
+  })
 })

--- a/packages/interwovenkit-react/src/pages/deposit/transferFooterState.test.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferFooterState.test.ts
@@ -1,0 +1,27 @@
+import { getTransferFooterStatus } from "./transferFooterState"
+
+describe("getTransferFooterStatus", () => {
+  it("shows insufficient balance when the transfer itself exceeds the source balance", () => {
+    expect(
+      getTransferFooterStatus({
+        feeDenom: "uinit",
+        sourceDenom: "uinit",
+        feeWarning: "Make sure to leave enough for transaction fee",
+        hasSourceBalance: false,
+        isFeeBalanceSufficient: false,
+      }),
+    ).toEqual({ error: "Insufficient balance" })
+  })
+
+  it("keeps the fee warning when the transfer fits but needs room for the fee", () => {
+    expect(
+      getTransferFooterStatus({
+        feeDenom: "uinit",
+        sourceDenom: "uinit",
+        feeWarning: "Make sure to leave enough for transaction fee",
+        hasSourceBalance: true,
+        isFeeBalanceSufficient: false,
+      }),
+    ).toEqual({ warning: "Make sure to leave enough for transaction fee" })
+  })
+})

--- a/packages/interwovenkit-react/src/pages/deposit/transferFooterState.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/transferFooterState.ts
@@ -1,0 +1,35 @@
+interface GetTransferFooterStatusArgs {
+  feeDenom?: string
+  sourceDenom: string
+  feeWarning?: string
+  hasSourceBalance: boolean
+  isFeeBalanceSufficient: boolean
+}
+
+interface TransferFooterStatus {
+  error?: string
+  warning?: string
+}
+
+export function getTransferFooterStatus({
+  feeDenom,
+  sourceDenom,
+  feeWarning,
+  hasSourceBalance,
+  isFeeBalanceSufficient,
+}: GetTransferFooterStatusArgs): TransferFooterStatus {
+  if (!hasSourceBalance) {
+    return { error: "Insufficient balance" }
+  }
+
+  const warning = feeDenom === sourceDenom ? feeWarning : undefined
+  if (warning) {
+    return { warning }
+  }
+
+  if (!isFeeBalanceSufficient) {
+    return { error: "Insufficient balance" }
+  }
+
+  return {}
+}


### PR DESCRIPTION
## Overview
This fixes the withdraw flow so a user with zero balance cannot fetch a route and reach an enabled withdraw confirm state.

## Root Cause
The regression traces back to PR #203, which intended to avoid flashing `Insufficient balance` while balances were still loading. That intent was reasonable, but the implementation used `balance === undefined` to mean “still loading.” In this flow, `undefined` could also mean the balances had already loaded and the selected denom was simply absent because the user had zero balance. That let zero-balance withdraws bypass validation.

## Fix
After the first balance snapshot is available, a missing selected denom is now treated as `0` instead of “unknown.” The withdraw form uses that resolved balance to block invalid amounts and prevent route fetching, and the footer also verifies source-asset sufficiency before enabling confirm.

Fixes: [EXP-299](https://linear.app/initia-labs/issue/EXP-299/disable-withdraw-when-balance-is-0)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transfer balance resolution and footer/route gating logic, which can affect whether users can proceed with deposit/withdraw flows and how errors/warnings display.
> 
> **Overview**
> Fixes a withdraw regression where a missing denom balance (`undefined`) could be treated as “still loading” and allow route fetching/confirmation with an effective zero balance.
> 
> Introduces `getResolvedTransferBalance` and `hasSufficientTransferBalance` to consistently treat missing balances as `0` after the first snapshot, updates `TransferFields` to gate validation/route queries/MAX behavior on the resolved balance, and centralizes footer error/warning selection via new `getTransferFooterStatus` (with added unit tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 373b9e4c3da7e76987337d5692c98972e2cb0bda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Balance display now waits for the first balances snapshot before showing/validating amounts; MAX and insufficient-balance gating behave correctly.
  * Footer now more reliably surfaces insufficient-balance errors instead of being suppressed in fee/source-denom edge cases.

* **New Features**
  * Centralized footer status logic to consistently show errors or warnings about fees and source balance.

* **Tests**
  * Added tests covering balance-resolution and sufficiency checks and footer status outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->