### PR TITLE
fix(bridge): guard preview fee checks for external chains

### DIFF
--- a/packages/interwovenkit-react/src/data/chains.test.ts
+++ b/packages/interwovenkit-react/src/data/chains.test.ts
@@ -1,0 +1,40 @@
+import type { NormalizedChain } from "./chains"
+import { resolveEnabledChainState } from "./chains"
+
+describe("resolveEnabledChainState", () => {
+  it("returns the query error when the registry fails before any data is cached", () => {
+    const error = new Error("Failed to load chains")
+
+    expect(
+      resolveEnabledChainState({
+        chainId: "initiation-1",
+        chains: undefined,
+        enabled: true,
+        error,
+        isLoading: false,
+      }),
+    ).toEqual({
+      chain: undefined,
+      error,
+      isLoading: false,
+    })
+  })
+
+  it("returns the cached chain even if a background refetch fails", () => {
+    const chain = { chain_id: "initiation-1" } as NormalizedChain
+
+    expect(
+      resolveEnabledChainState({
+        chainId: chain.chain_id,
+        chains: [chain],
+        enabled: true,
+        error: new Error("background refetch failed"),
+        isLoading: false,
+      }),
+    ).toEqual({
+      chain,
+      error: null,
+      isLoading: false,
+    })
+  })
+})

--- a/packages/interwovenkit-react/src/data/chains.test.ts
+++ b/packages/interwovenkit-react/src/data/chains.test.ts
@@ -1,5 +1,27 @@
+import type { Chain } from "@initia/initia-registry-types"
 import type { NormalizedChain } from "./chains"
-import { resolveEnabledChainState } from "./chains"
+import {
+  chainQueryKeys,
+  createInitiaRegistryQueryOptions,
+  resolveEnabledChainState,
+} from "./chains"
+
+function createChain(chainId: string, prettyName = chainId): Chain {
+  return {
+    apis: {
+      indexer: [{ address: `https://${chainId}.indexer.example.com` }],
+      rest: [{ address: `https://${chainId}.rest.example.com` }],
+      rpc: [{ address: `https://${chainId}.rpc.example.com` }],
+    },
+    bech32_prefix: "init",
+    chain_id: chainId,
+    chain_name: chainId,
+    fees: { fee_tokens: [] },
+    metadata: {},
+    network_type: "testnet",
+    pretty_name: prettyName,
+  } as Chain
+}
 
 describe("resolveEnabledChainState", () => {
   it("returns the query error when the registry fails before any data is cached", () => {
@@ -36,5 +58,27 @@ describe("resolveEnabledChainState", () => {
       error: null,
       isLoading: false,
     })
+  })
+})
+
+describe("createInitiaRegistryQueryOptions", () => {
+  it("reuses one select path for custom-chain replacement and default sorting", () => {
+    const customChain = createChain("initiation-2", "Custom chain")
+    const options = createInitiaRegistryQueryOptions({
+      customChain,
+      defaultChainId: "initiation-2",
+      registryUrl: "https://registry.example.com",
+    })
+
+    expect(options.queryKey).toEqual(chainQueryKeys.list("https://registry.example.com").queryKey)
+    expect(
+      options.select?.([
+        createChain("initiation-1"),
+        createChain("initiation-2", "Original chain"),
+      ]),
+    ).toMatchObject([
+      { chainId: "initiation-2", name: "Custom chain" },
+      { chainId: "initiation-1", name: "initiation-1" },
+    ])
   })
 })

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -49,6 +49,22 @@ export function useInitiaRegistry() {
   return data
 }
 
+function useInitiaRegistryEnabled(enabled: boolean) {
+  const { defaultChainId, registryUrl, customChain } = useConfig()
+  return useQuery({
+    queryKey: chainQueryKeys.list(registryUrl).queryKey,
+    queryFn: () => ky.create({ prefixUrl: registryUrl }).get("chains.json").json<Chain[]>(),
+    select: (rawChains: Chain[]) => {
+      const chains = customChain
+        ? [customChain, ...rawChains.filter((chain) => chain.chain_id !== customChain.chain_id)]
+        : rawChains
+      return chains.map(normalizeChain).sort(descend((chain) => chain.chainId === defaultChainId))
+    },
+    staleTime: STALE_TIMES.MINUTE,
+    enabled,
+  })
+}
+
 export function useProfilesRegistry() {
   const { registryUrl } = useConfig()
   const { data } = useSuspenseQuery({
@@ -58,6 +74,17 @@ export function useProfilesRegistry() {
     staleTime: STALE_TIMES.MINUTE,
   })
   return data
+}
+
+function useProfilesRegistryEnabled(enabled: boolean) {
+  const { registryUrl } = useConfig()
+  return useQuery({
+    queryKey: chainQueryKeys.profiles(registryUrl).queryKey,
+    queryFn: () =>
+      ky.create({ prefixUrl: registryUrl }).get("profiles.json").json<ChainProfile[]>(),
+    staleTime: STALE_TIMES.MINUTE,
+    enabled,
+  })
 }
 
 export function useFindChain() {
@@ -95,6 +122,70 @@ export function useFindChain() {
 export function useChain(chainId: string) {
   const findChain = useFindChain()
   return findChain(chainId)
+}
+
+export function useChainEnabled(chainId: string, enabled: boolean) {
+  const chainsQuery = useInitiaRegistryEnabled(enabled)
+  const profilesQuery = useProfilesRegistryEnabled(enabled)
+
+  if (!enabled) {
+    return { chain: undefined, error: null, isLoading: false }
+  }
+
+  const queryError = chainsQuery.error ?? profilesQuery.error
+  if (queryError) {
+    return {
+      chain: undefined,
+      error: queryError instanceof Error ? queryError : new Error("Failed to load chains"),
+      isLoading: false,
+    }
+  }
+
+  if (chainsQuery.isLoading || profilesQuery.isLoading) {
+    return { chain: undefined, error: null, isLoading: true }
+  }
+
+  const chains = chainsQuery.data
+  const profiles = profilesQuery.data
+  if (!(chains && profiles)) {
+    return { chain: undefined, error: null, isLoading: true }
+  }
+
+  const chain = chains.find((chain) => chain.chain_id === chainId)
+  if (chain) {
+    return { chain, error: null, isLoading: false }
+  }
+
+  const profile = profiles.find((profile) => profile.chain_id === chainId)
+  if (!profile) {
+    return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
+  }
+
+  const layer1 = chains.find((chain) => chain.metadata?.is_l1)
+  if (!layer1) {
+    return { chain: undefined, error: new Error("Layer 1 not found"), isLoading: false }
+  }
+
+  return {
+    chain: {
+      chain_id: profile.chain_id,
+      chain_name: profile.name,
+      pretty_name: profile.pretty_name,
+      network_type: layer1.network_type,
+      bech32_prefix: "init" as const,
+      fees: { fee_tokens: [] },
+      apis: { rpc: [], rest: [], indexer: [] },
+      chainId,
+      name: profile.pretty_name,
+      logoUrl: profile.logo,
+      rpcUrl: "",
+      restUrl: "",
+      indexerUrl: "",
+      jsonRpcUrl: "",
+    } as NormalizedChain,
+    error: null,
+    isLoading: false,
+  }
 }
 
 export function useDefaultChain() {

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -78,25 +78,16 @@ export function resolveEnabledChainState({
   return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
 }
 
-export function useInitiaRegistry() {
-  const { defaultChainId, registryUrl, customChain } = useConfig()
-  const { data } = useSuspenseQuery({
-    queryKey: chainQueryKeys.list(registryUrl).queryKey,
-    queryFn: () => ky.create({ prefixUrl: registryUrl }).get("chains.json").json<Chain[]>(),
-    select: (rawChains) => {
-      const chains = customChain
-        ? [customChain, ...rawChains.filter((chain) => chain.chain_id !== customChain.chain_id)]
-        : rawChains
-      return chains.map(normalizeChain).sort(descend((chain) => chain.chainId === defaultChainId))
-    },
-    staleTime: STALE_TIMES.MINUTE,
-  })
-  return data
-}
-
-function useInitiaRegistryEnabled(enabled: boolean) {
-  const { defaultChainId, registryUrl, customChain } = useConfig()
-  return useQuery({
+export function createInitiaRegistryQueryOptions({
+  customChain,
+  defaultChainId,
+  registryUrl,
+}: {
+  customChain?: Chain
+  defaultChainId: string
+  registryUrl: string
+}) {
+  return queryOptions({
     queryKey: chainQueryKeys.list(registryUrl).queryKey,
     queryFn: () => ky.create({ prefixUrl: registryUrl }).get("chains.json").json<Chain[]>(),
     select: (rawChains: Chain[]) => {
@@ -106,6 +97,21 @@ function useInitiaRegistryEnabled(enabled: boolean) {
       return chains.map(normalizeChain).sort(descend((chain) => chain.chainId === defaultChainId))
     },
     staleTime: STALE_TIMES.MINUTE,
+  })
+}
+
+export function useInitiaRegistry() {
+  const { defaultChainId, registryUrl, customChain } = useConfig()
+  const { data } = useSuspenseQuery(
+    createInitiaRegistryQueryOptions({ customChain, defaultChainId, registryUrl }),
+  )
+  return data
+}
+
+function useInitiaRegistryEnabled(enabled: boolean) {
+  const { defaultChainId, registryUrl, customChain } = useConfig()
+  return useQuery({
+    ...createInitiaRegistryQueryOptions({ customChain, defaultChainId, registryUrl }),
     enabled,
   })
 }

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -33,6 +33,51 @@ function normalizeChain(chain: Chain) {
 
 export type NormalizedChain = ReturnType<typeof normalizeChain>
 
+export function resolveEnabledChainState({
+  chainId,
+  chains,
+  enabled,
+  error,
+  isLoading,
+}: {
+  chainId: string
+  chains?: NormalizedChain[]
+  enabled: boolean
+  error: unknown
+  isLoading: boolean
+}) {
+  if (!enabled) {
+    return { chain: undefined, error: null, isLoading: false }
+  }
+
+  const chain = chains?.find((chain) => chain.chain_id === chainId)
+  if (chain) {
+    return { chain, error: null, isLoading: false }
+  }
+
+  if (error && !chains) {
+    return {
+      chain: undefined,
+      error: error instanceof Error ? error : new Error("Failed to load chains"),
+      isLoading: false,
+    }
+  }
+
+  if (isLoading || !chains) {
+    return { chain: undefined, error: null, isLoading: true }
+  }
+
+  if (error) {
+    return {
+      chain: undefined,
+      error: error instanceof Error ? error : new Error("Failed to load chains"),
+      isLoading: false,
+    }
+  }
+
+  return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
+}
+
 export function useInitiaRegistry() {
   const { defaultChainId, registryUrl, customChain } = useConfig()
   const { data } = useSuspenseQuery({
@@ -115,35 +160,13 @@ export function useChain(chainId: string) {
 
 export function useChainEnabled(chainId: string, enabled: boolean) {
   const chainsQuery = useInitiaRegistryEnabled(enabled)
-
-  if (!enabled) {
-    return { chain: undefined, error: null, isLoading: false }
-  }
-
-  if (chainsQuery.isLoading && !chainsQuery.data) {
-    return { chain: undefined, error: null, isLoading: true }
-  }
-
-  const chains = chainsQuery.data
-  if (!chains) {
-    return { chain: undefined, error: null, isLoading: true }
-  }
-
-  const chain = chains.find((chain) => chain.chain_id === chainId)
-  if (chain) {
-    return { chain, error: null, isLoading: false }
-  }
-
-  if (chainsQuery.error) {
-    return {
-      chain: undefined,
-      error:
-        chainsQuery.error instanceof Error ? chainsQuery.error : new Error("Failed to load chains"),
-      isLoading: false,
-    }
-  }
-
-  return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
+  return resolveEnabledChainState({
+    chainId,
+    chains: chainsQuery.data,
+    enabled,
+    error: chainsQuery.error,
+    isLoading: chainsQuery.isLoading,
+  })
 }
 
 export function useDefaultChain() {

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -76,17 +76,6 @@ export function useProfilesRegistry() {
   return data
 }
 
-function useProfilesRegistryEnabled(enabled: boolean) {
-  const { registryUrl } = useConfig()
-  return useQuery({
-    queryKey: chainQueryKeys.profiles(registryUrl).queryKey,
-    queryFn: () =>
-      ky.create({ prefixUrl: registryUrl }).get("profiles.json").json<ChainProfile[]>(),
-    staleTime: STALE_TIMES.MINUTE,
-    enabled,
-  })
-}
-
 export function useFindChain() {
   const layer1 = useLayer1()
   const chains = useInitiaRegistry()
@@ -126,22 +115,12 @@ export function useChain(chainId: string) {
 
 export function useChainEnabled(chainId: string, enabled: boolean) {
   const chainsQuery = useInitiaRegistryEnabled(enabled)
-  const profilesQuery = useProfilesRegistryEnabled(enabled)
 
   if (!enabled) {
     return { chain: undefined, error: null, isLoading: false }
   }
 
-  if (chainsQuery.error) {
-    return {
-      chain: undefined,
-      error:
-        chainsQuery.error instanceof Error ? chainsQuery.error : new Error("Failed to load chains"),
-      isLoading: false,
-    }
-  }
-
-  if (chainsQuery.isLoading) {
+  if (chainsQuery.isLoading && !chainsQuery.data) {
     return { chain: undefined, error: null, isLoading: true }
   }
 
@@ -155,56 +134,16 @@ export function useChainEnabled(chainId: string, enabled: boolean) {
     return { chain, error: null, isLoading: false }
   }
 
-  if (profilesQuery.error) {
+  if (chainsQuery.error) {
     return {
       chain: undefined,
       error:
-        profilesQuery.error instanceof Error
-          ? profilesQuery.error
-          : new Error("Failed to load chains"),
+        chainsQuery.error instanceof Error ? chainsQuery.error : new Error("Failed to load chains"),
       isLoading: false,
     }
   }
 
-  if (profilesQuery.isLoading) {
-    return { chain: undefined, error: null, isLoading: true }
-  }
-
-  const profiles = profilesQuery.data
-  if (!profiles) {
-    return { chain: undefined, error: null, isLoading: true }
-  }
-
-  const profile = profiles.find((profile) => profile.chain_id === chainId)
-  if (!profile) {
-    return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
-  }
-
-  const layer1 = chains.find((chain) => chain.metadata?.is_l1)
-  if (!layer1) {
-    return { chain: undefined, error: new Error("Layer 1 not found"), isLoading: false }
-  }
-
-  return {
-    chain: {
-      chain_id: profile.chain_id,
-      chain_name: profile.name,
-      pretty_name: profile.pretty_name,
-      network_type: layer1.network_type,
-      bech32_prefix: "init" as const,
-      fees: { fee_tokens: [] },
-      apis: { rpc: [], rest: [], indexer: [] },
-      chainId,
-      name: profile.pretty_name,
-      logoUrl: profile.logo,
-      rpcUrl: "",
-      restUrl: "",
-      indexerUrl: "",
-      jsonRpcUrl: "",
-    } as NormalizedChain,
-    error: null,
-    isLoading: false,
-  }
+  return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
 }
 
 export function useDefaultChain() {

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -132,28 +132,47 @@ export function useChainEnabled(chainId: string, enabled: boolean) {
     return { chain: undefined, error: null, isLoading: false }
   }
 
-  const queryError = chainsQuery.error ?? profilesQuery.error
-  if (queryError) {
+  if (chainsQuery.error) {
     return {
       chain: undefined,
-      error: queryError instanceof Error ? queryError : new Error("Failed to load chains"),
+      error:
+        chainsQuery.error instanceof Error ? chainsQuery.error : new Error("Failed to load chains"),
       isLoading: false,
     }
   }
 
-  if (chainsQuery.isLoading || profilesQuery.isLoading) {
+  if (chainsQuery.isLoading) {
     return { chain: undefined, error: null, isLoading: true }
   }
 
   const chains = chainsQuery.data
-  const profiles = profilesQuery.data
-  if (!(chains && profiles)) {
+  if (!chains) {
     return { chain: undefined, error: null, isLoading: true }
   }
 
   const chain = chains.find((chain) => chain.chain_id === chainId)
   if (chain) {
     return { chain, error: null, isLoading: false }
+  }
+
+  if (profilesQuery.error) {
+    return {
+      chain: undefined,
+      error:
+        profilesQuery.error instanceof Error
+          ? profilesQuery.error
+          : new Error("Failed to load chains"),
+      isLoading: false,
+    }
+  }
+
+  if (profilesQuery.isLoading) {
+    return { chain: undefined, error: null, isLoading: true }
+  }
+
+  const profiles = profilesQuery.data
+  if (!profiles) {
+    return { chain: undefined, error: null, isLoading: true }
   }
 
   const profile = profiles.find((profile) => profile.chain_id === chainId)

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -58,7 +58,7 @@ export function resolveEnabledChainState({
   if (error && !chains) {
     return {
       chain: undefined,
-      error: error instanceof Error ? error : new Error("Failed to load chains"),
+      error: error instanceof Error ? error : new Error(`Failed to load chains: ${String(error)}`),
       isLoading: false,
     }
   }
@@ -70,7 +70,7 @@ export function resolveEnabledChainState({
   if (error) {
     return {
       chain: undefined,
-      error: error instanceof Error ? error : new Error("Failed to load chains"),
+      error: error instanceof Error ? error : new Error(`Failed to load chains: ${String(error)}`),
       isLoading: false,
     }
   }

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -1,13 +1,13 @@
 import type { TxJson } from "@skip-go/client"
-import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { useChain } from "@/data/chains"
+import { useFindChain } from "@/data/chains"
 import { fetchGasPrices } from "@/data/fee"
 import { normalizeError } from "@/data/http"
 import { useAminoConverters, useAminoTypes, useCreateSigningStargateClient } from "@/data/signer"
 import { useSkipBalancesQuery } from "./data/balance"
 import { computeRequiredFeeByDenom, hasSufficientFeeBalance } from "./data/bridgeTxUtils"
 import { useChainType, useSkipChain } from "./data/chains"
+import { getExactFeeCheckSetup } from "./data/exactFeeCheck"
 import { decodeCosmosAminoMessages, useBridgePreviewState } from "./data/tx"
 
 import type { ReactNode } from "react"
@@ -17,25 +17,10 @@ interface Props {
   children: (status: { exactFeeCheckError?: string; isCheckingFeeBalance: boolean }) => ReactNode
 }
 
-function getFeeBalanceKey({
-  balances,
-  feeDenoms,
-}: {
-  balances?: Record<string, { amount?: string }>
-  feeDenoms: string[]
-}): string {
-  if (!balances) return ""
-
-  return feeDenoms
-    .toSorted()
-    .map((denom) => `${denom}:${balances[denom]?.amount ?? "0"}`)
-    .join("|")
-}
-
 function FooterWithExactFeeCheck({ tx, children }: Props) {
   const { route, values } = useBridgePreviewState()
   const { sender, recipient, srcChainId, srcDenom, dstChainId } = values
-  const chain = useChain(srcChainId)
+  const findChain = useFindChain()
   const srcChain = useSkipChain(srcChainId)
   const dstChain = useSkipChain(dstChainId)
   const srcChainType = useChainType(srcChain)
@@ -48,20 +33,18 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
   const aminoConverters = useAminoConverters()
   const aminoTypes = useAminoTypes()
   const createSigningStargateClient = useCreateSigningStargateClient()
-  const feeDenoms = useMemo(
-    () => Array.from(new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)])),
-    [chain.fees.fee_tokens, srcDenom],
-  )
-  const balanceKey = useMemo(() => getFeeBalanceKey({ balances, feeDenoms }), [balances, feeDenoms])
-
-  const requiresExactFeeCheck =
-    "cosmos_tx" in tx &&
-    !!tx.cosmos_tx.msgs?.length &&
-    !route.required_op_hook &&
-    srcChainType === "initia" &&
-    dstChainType === "initia" &&
-    !!sender &&
-    !!recipient
+  const exactFeeCheck = getExactFeeCheckSetup({
+    balances,
+    dstChainType,
+    findChain,
+    recipient,
+    route,
+    sender,
+    srcChainId,
+    srcChainType,
+    srcDenom,
+    tx,
+  })
 
   const {
     data: hasFeeBalance,
@@ -75,11 +58,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
       srcChainId,
       srcDenom,
       route.amount_in,
-      balanceKey,
+      exactFeeCheck?.balanceKey,
     ],
     queryFn: async () => {
       try {
-        if (!("cosmos_tx" in tx) || !tx.cosmos_tx.msgs?.length || !balances) {
+        if (!(exactFeeCheck && "cosmos_tx" in tx && tx.cosmos_tx.msgs?.length && balances)) {
           throw new Error("Invalid transaction data")
         }
 
@@ -89,7 +72,7 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
         })
         const client = await createSigningStargateClient(srcChainId)
         const gas = await client.simulate(sender, messages, "")
-        const gasPrices = await fetchGasPrices(chain)
+        const gasPrices = await fetchGasPrices(findChain(srcChainId))
         const requiredFeeByDenom = computeRequiredFeeByDenom({
           gas,
           gasPrices,
@@ -105,11 +88,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
         throw await normalizeError(error)
       }
     },
-    enabled: requiresExactFeeCheck && balances !== undefined,
+    enabled: !!exactFeeCheck && balances !== undefined,
     retry: false,
   })
 
-  if (!requiresExactFeeCheck) {
+  if (!exactFeeCheck) {
     return children({ isCheckingFeeBalance: false })
   }
 

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -134,7 +134,8 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
 
   if (balancesError) {
     return children({
-      exactFeeCheckError: balancesError instanceof Error ? balancesError.message : "Failed to load balances",
+      exactFeeCheckError:
+        balancesError instanceof Error ? balancesError.message : "Failed to load balances",
       isCheckingFeeBalance: false,
     })
   }

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -134,7 +134,7 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
 
   if (balancesError) {
     return children({
-      exactFeeCheckError: "Failed to load balances",
+      exactFeeCheckError: balancesError instanceof Error ? balancesError.message : "Failed to load balances",
       isCheckingFeeBalance: false,
     })
   }

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -1,6 +1,6 @@
 import type { TxJson } from "@skip-go/client"
 import { useQuery } from "@tanstack/react-query"
-import { useFindChain } from "@/data/chains"
+import { useChainEnabled } from "@/data/chains"
 import { fetchGasPrices } from "@/data/fee"
 import { normalizeError } from "@/data/http"
 import { useAminoConverters, useAminoTypes, useCreateSigningStargateClient } from "@/data/signer"
@@ -35,7 +35,6 @@ function getFeeBalanceKey({
 function FooterWithExactFeeCheck({ tx, children }: Props) {
   const { route, values } = useBridgePreviewState()
   const { sender, recipient, srcChainId, srcDenom, dstChainId } = values
-  const findChain = useFindChain()
   const srcChain = useSkipChain(srcChainId)
   const dstChain = useSkipChain(dstChainId)
   const srcChainType = useChainType(srcChain)
@@ -56,7 +55,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
     srcChainType,
     tx,
   })
-  const chain = requiresExactFeeCheck ? findChain(srcChainId) : undefined
+  const {
+    chain,
+    error: chainError,
+    isLoading: isLoadingChain,
+  } = useChainEnabled(srcChainId, requiresExactFeeCheck)
   const feeDenoms = chain
     ? Array.from(new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)]))
     : []
@@ -120,6 +123,10 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
     return children({ isCheckingFeeBalance: false })
   }
 
+  if (chainError) {
+    return children({ exactFeeCheckError: chainError.message, isCheckingFeeBalance: false })
+  }
+
   if (balancesError) {
     return children({
       exactFeeCheckError: "Failed to load balances",
@@ -127,7 +134,7 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
     })
   }
 
-  if (isLoadingBalances || balances === undefined || isLoading) {
+  if (isLoadingChain || isLoadingBalances || balances === undefined || isLoading) {
     return children({ isCheckingFeeBalance: true })
   }
 

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -48,12 +48,12 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
   const aminoTypes = useAminoTypes()
   const createSigningStargateClient = useCreateSigningStargateClient()
   const requiresExactFeeCheck = shouldCheckExactFee({
-    isDstInitia: dstChainType === "initia",
-    recipient,
     route,
-    sender,
-    isSrcInitia: srcChainType === "initia",
     tx,
+    isSrcInitia: srcChainType === "initia",
+    isDstInitia: dstChainType === "initia",
+    sender,
+    recipient,
   })
   const {
     chain,

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -48,11 +48,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
   const aminoTypes = useAminoTypes()
   const createSigningStargateClient = useCreateSigningStargateClient()
   const requiresExactFeeCheck = shouldCheckExactFee({
-    dstChainType,
+    isDstInitia: dstChainType === "initia",
     recipient,
     route,
     sender,
-    srcChainType,
+    isSrcInitia: srcChainType === "initia",
     tx,
   })
   const {

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -7,7 +7,7 @@ import { useAminoConverters, useAminoTypes, useCreateSigningStargateClient } fro
 import { useSkipBalancesQuery } from "./data/balance"
 import { computeRequiredFeeByDenom, hasSufficientFeeBalance } from "./data/bridgeTxUtils"
 import { useChainType, useSkipChain } from "./data/chains"
-import { shouldCheckExactFee } from "./data/exactFeeCheck"
+import { shouldCheckExactFee, shouldRunExactFeeQuery } from "./data/exactFeeCheck"
 import { decodeCosmosAminoMessages, useBridgePreviewState } from "./data/tx"
 
 import type { ReactNode } from "react"
@@ -64,6 +64,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
     ? Array.from(new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)]))
     : []
   const balanceKey = getFeeBalanceKey({ balances, feeDenoms })
+  const shouldRunFeeQuery = shouldRunExactFeeQuery({
+    hasBalances: balances !== undefined,
+    hasChain: !!chain,
+    requiresExactFeeCheck,
+  })
 
   const {
     data: hasFeeBalance,
@@ -115,7 +120,7 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
         throw await normalizeError(error)
       }
     },
-    enabled: requiresExactFeeCheck && balances !== undefined,
+    enabled: shouldRunFeeQuery,
     retry: false,
   })
 

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -7,7 +7,7 @@ import { useAminoConverters, useAminoTypes, useCreateSigningStargateClient } fro
 import { useSkipBalancesQuery } from "./data/balance"
 import { computeRequiredFeeByDenom, hasSufficientFeeBalance } from "./data/bridgeTxUtils"
 import { useChainType, useSkipChain } from "./data/chains"
-import { getExactFeeCheckSetup } from "./data/exactFeeCheck"
+import { shouldCheckExactFee } from "./data/exactFeeCheck"
 import { decodeCosmosAminoMessages, useBridgePreviewState } from "./data/tx"
 
 import type { ReactNode } from "react"
@@ -15,6 +15,21 @@ import type { ReactNode } from "react"
 interface Props {
   tx: TxJson
   children: (status: { exactFeeCheckError?: string; isCheckingFeeBalance: boolean }) => ReactNode
+}
+
+function getFeeBalanceKey({
+  balances,
+  feeDenoms,
+}: {
+  balances?: Record<string, { amount?: string }>
+  feeDenoms: string[]
+}): string {
+  if (!balances) return ""
+
+  return feeDenoms
+    .toSorted()
+    .map((denom) => `${denom}:${balances[denom]?.amount ?? "0"}`)
+    .join("|")
 }
 
 function FooterWithExactFeeCheck({ tx, children }: Props) {
@@ -33,18 +48,19 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
   const aminoConverters = useAminoConverters()
   const aminoTypes = useAminoTypes()
   const createSigningStargateClient = useCreateSigningStargateClient()
-  const exactFeeCheck = getExactFeeCheckSetup({
-    balances,
+  const requiresExactFeeCheck = shouldCheckExactFee({
     dstChainType,
-    findChain,
     recipient,
     route,
     sender,
-    srcChainId,
     srcChainType,
-    srcDenom,
     tx,
   })
+  const chain = requiresExactFeeCheck ? findChain(srcChainId) : undefined
+  const feeDenoms = chain
+    ? Array.from(new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)]))
+    : []
+  const balanceKey = getFeeBalanceKey({ balances, feeDenoms })
 
   const {
     data: hasFeeBalance,
@@ -58,11 +74,19 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
       srcChainId,
       srcDenom,
       route.amount_in,
-      exactFeeCheck?.balanceKey,
+      balanceKey,
     ],
     queryFn: async () => {
       try {
-        if (!(exactFeeCheck && "cosmos_tx" in tx && tx.cosmos_tx.msgs?.length && balances)) {
+        if (
+          !(
+            requiresExactFeeCheck &&
+            chain &&
+            "cosmos_tx" in tx &&
+            tx.cosmos_tx.msgs?.length &&
+            balances
+          )
+        ) {
           throw new Error("Invalid transaction data")
         }
 
@@ -72,7 +96,7 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
         })
         const client = await createSigningStargateClient(srcChainId)
         const gas = await client.simulate(sender, messages, "")
-        const gasPrices = await fetchGasPrices(findChain(srcChainId))
+        const gasPrices = await fetchGasPrices(chain)
         const requiredFeeByDenom = computeRequiredFeeByDenom({
           gas,
           gasPrices,
@@ -88,11 +112,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
         throw await normalizeError(error)
       }
     },
-    enabled: !!exactFeeCheck && balances !== undefined,
+    enabled: requiresExactFeeCheck && balances !== undefined,
     retry: false,
   })
 
-  if (!exactFeeCheck) {
+  if (!requiresExactFeeCheck) {
     return children({ isCheckingFeeBalance: false })
   }
 

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
@@ -65,7 +65,7 @@ describe("getExactFeeCheckSetup", () => {
     expect(findChain).not.toHaveBeenCalled()
   })
 
-  it("builds fee context for initia cosmos routes", () => {
+  it("builds fee context for initia-to-initia routes", () => {
     const findChain = vi.fn(
       () =>
         ({

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
@@ -1,5 +1,5 @@
 import type { TxJson } from "@skip-go/client"
-import { shouldCheckExactFee } from "./exactFeeCheck"
+import { shouldCheckExactFee, shouldRunExactFeeQuery } from "./exactFeeCheck"
 
 describe("shouldCheckExactFee", () => {
   it("returns false for cosmos-to-initia routes", () => {
@@ -57,5 +57,17 @@ describe("shouldCheckExactFee", () => {
         } as TxJson,
       }),
     ).toBe(true)
+  })
+})
+
+describe("shouldRunExactFeeQuery", () => {
+  it("returns false until both balances and chain data are available", () => {
+    expect(
+      shouldRunExactFeeQuery({
+        hasBalances: true,
+        hasChain: false,
+        requiresExactFeeCheck: true,
+      }),
+    ).toBe(false)
   })
 })

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
@@ -1,106 +1,61 @@
 import type { TxJson } from "@skip-go/client"
-import type { NormalizedChain } from "@/data/chains"
-import { getExactFeeCheckSetup } from "./exactFeeCheck"
+import { shouldCheckExactFee } from "./exactFeeCheck"
 
-describe("getExactFeeCheckSetup", () => {
-  it("skips external routes without resolving initia registry chains", () => {
-    const findChain = vi.fn(() => {
-      throw new Error("should not resolve initia chain")
-    })
-
-    const result = getExactFeeCheckSetup({
-      balances: {
-        uusdc: { amount: "1000" },
-      },
-      dstChainType: "initia",
-      findChain,
-      recipient: "init1recipient",
-      route: {
-        amount_in: "100",
-        required_op_hook: false,
-      },
-      sender: "noble1sender",
-      srcChainId: "noble-1",
-      srcChainType: "cosmos",
-      srcDenom: "uusdc",
-      tx: {
-        cosmos_tx: {
-          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+describe("shouldCheckExactFee", () => {
+  it("returns false for cosmos-to-initia routes", () => {
+    expect(
+      shouldCheckExactFee({
+        dstChainType: "initia",
+        recipient: "init1recipient",
+        route: {
+          required_op_hook: false,
         },
-      } as TxJson,
-    })
-
-    expect(result).toBeNull()
-    expect(findChain).not.toHaveBeenCalled()
-  })
-
-  it("skips initia routes when the destination chain is external", () => {
-    const findChain = vi.fn(() => {
-      throw new Error("should not resolve initia chain")
-    })
-
-    const result = getExactFeeCheckSetup({
-      balances: {
-        uinit: { amount: "1000" },
-      },
-      dstChainType: "cosmos",
-      findChain,
-      recipient: "celestia1recipient",
-      route: {
-        amount_in: "100",
-        required_op_hook: false,
-      },
-      sender: "init1sender",
-      srcChainId: "initia-1",
-      srcChainType: "initia",
-      srcDenom: "uinit",
-      tx: {
-        cosmos_tx: {
-          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
-        },
-      } as TxJson,
-    })
-
-    expect(result).toBeNull()
-    expect(findChain).not.toHaveBeenCalled()
-  })
-
-  it("builds fee context for initia-to-initia routes", () => {
-    const findChain = vi.fn(
-      () =>
-        ({
-          fees: {
-            fee_tokens: [{ denom: "uinit" }, { denom: "uusdc" }],
+        sender: "noble1sender",
+        srcChainType: "cosmos",
+        tx: {
+          cosmos_tx: {
+            msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
           },
-        }) as NormalizedChain,
-    )
+        } as TxJson,
+      }),
+    ).toBe(false)
+  })
 
-    const result = getExactFeeCheckSetup({
-      balances: {
-        uinit: { amount: "2000" },
-        uusdc: { amount: "500" },
-      },
-      dstChainType: "initia",
-      findChain,
-      recipient: "init1recipient",
-      route: {
-        amount_in: "100",
-        required_op_hook: false,
-      },
-      sender: "init1sender",
-      srcChainId: "initia-1",
-      srcChainType: "initia",
-      srcDenom: "uinit",
-      tx: {
-        cosmos_tx: {
-          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+  it("returns false for initia-to-cosmos routes", () => {
+    expect(
+      shouldCheckExactFee({
+        dstChainType: "cosmos",
+        recipient: "celestia1recipient",
+        route: {
+          required_op_hook: false,
         },
-      } as TxJson,
-    })
+        sender: "init1sender",
+        srcChainType: "initia",
+        tx: {
+          cosmos_tx: {
+            msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+          },
+        } as TxJson,
+      }),
+    ).toBe(false)
+  })
 
-    expect(findChain).toHaveBeenCalledWith("initia-1")
-    expect(result).toEqual({
-      balanceKey: "uinit:2000|uusdc:500",
-    })
+  it("returns true for initia-to-initia routes", () => {
+    expect(
+      shouldCheckExactFee({
+        dstChainType: "initia",
+        recipient: "init1recipient",
+        route: {
+          required_op_hook: false,
+        },
+        sender: "init1sender",
+        srcChainType: "initia",
+        tx: {
+          cosmos_tx: {
+            msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+          },
+        } as TxJson,
+      }),
+    ).toBe(true)
   })
 })

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
@@ -1,0 +1,106 @@
+import type { TxJson } from "@skip-go/client"
+import type { NormalizedChain } from "@/data/chains"
+import { getExactFeeCheckSetup } from "./exactFeeCheck"
+
+describe("getExactFeeCheckSetup", () => {
+  it("skips external routes without resolving initia registry chains", () => {
+    const findChain = vi.fn(() => {
+      throw new Error("should not resolve initia chain")
+    })
+
+    const result = getExactFeeCheckSetup({
+      balances: {
+        uusdc: { amount: "1000" },
+      },
+      dstChainType: "initia",
+      findChain,
+      recipient: "init1recipient",
+      route: {
+        amount_in: "100",
+        required_op_hook: false,
+      },
+      sender: "noble1sender",
+      srcChainId: "noble-1",
+      srcChainType: "cosmos",
+      srcDenom: "uusdc",
+      tx: {
+        cosmos_tx: {
+          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+        },
+      } as TxJson,
+    })
+
+    expect(result).toBeNull()
+    expect(findChain).not.toHaveBeenCalled()
+  })
+
+  it("skips initia routes when the destination chain is external", () => {
+    const findChain = vi.fn(() => {
+      throw new Error("should not resolve initia chain")
+    })
+
+    const result = getExactFeeCheckSetup({
+      balances: {
+        uinit: { amount: "1000" },
+      },
+      dstChainType: "cosmos",
+      findChain,
+      recipient: "celestia1recipient",
+      route: {
+        amount_in: "100",
+        required_op_hook: false,
+      },
+      sender: "init1sender",
+      srcChainId: "initia-1",
+      srcChainType: "initia",
+      srcDenom: "uinit",
+      tx: {
+        cosmos_tx: {
+          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+        },
+      } as TxJson,
+    })
+
+    expect(result).toBeNull()
+    expect(findChain).not.toHaveBeenCalled()
+  })
+
+  it("builds fee context for initia cosmos routes", () => {
+    const findChain = vi.fn(
+      () =>
+        ({
+          fees: {
+            fee_tokens: [{ denom: "uinit" }, { denom: "uusdc" }],
+          },
+        }) as NormalizedChain,
+    )
+
+    const result = getExactFeeCheckSetup({
+      balances: {
+        uinit: { amount: "2000" },
+        uusdc: { amount: "500" },
+      },
+      dstChainType: "initia",
+      findChain,
+      recipient: "init1recipient",
+      route: {
+        amount_in: "100",
+        required_op_hook: false,
+      },
+      sender: "init1sender",
+      srcChainId: "initia-1",
+      srcChainType: "initia",
+      srcDenom: "uinit",
+      tx: {
+        cosmos_tx: {
+          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+        },
+      } as TxJson,
+    })
+
+    expect(findChain).toHaveBeenCalledWith("initia-1")
+    expect(result).toEqual({
+      balanceKey: "uinit:2000|uusdc:500",
+    })
+  })
+})

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
@@ -5,13 +5,13 @@ describe("shouldCheckExactFee", () => {
   it("returns false for cosmos-to-initia routes", () => {
     expect(
       shouldCheckExactFee({
-        dstChainType: "initia",
+        isDstInitia: true,
         recipient: "init1recipient",
         route: {
           required_op_hook: false,
         },
         sender: "noble1sender",
-        srcChainType: "cosmos",
+        isSrcInitia: false,
         tx: {
           cosmos_tx: {
             msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
@@ -24,13 +24,13 @@ describe("shouldCheckExactFee", () => {
   it("returns false for initia-to-cosmos routes", () => {
     expect(
       shouldCheckExactFee({
-        dstChainType: "cosmos",
+        isDstInitia: false,
         recipient: "celestia1recipient",
         route: {
           required_op_hook: false,
         },
         sender: "init1sender",
-        srcChainType: "initia",
+        isSrcInitia: true,
         tx: {
           cosmos_tx: {
             msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
@@ -43,13 +43,13 @@ describe("shouldCheckExactFee", () => {
   it("returns true for initia-to-initia routes", () => {
     expect(
       shouldCheckExactFee({
-        dstChainType: "initia",
+        isDstInitia: true,
         recipient: "init1recipient",
         route: {
           required_op_hook: false,
         },
         sender: "init1sender",
-        srcChainType: "initia",
+        isSrcInitia: true,
         tx: {
           cosmos_tx: {
             msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
@@ -5,18 +5,18 @@ describe("shouldCheckExactFee", () => {
   it("returns false for cosmos-to-initia routes", () => {
     expect(
       shouldCheckExactFee({
-        isDstInitia: true,
-        recipient: "init1recipient",
         route: {
           required_op_hook: false,
         },
-        sender: "noble1sender",
-        isSrcInitia: false,
         tx: {
           cosmos_tx: {
             msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
           },
         } as TxJson,
+        isSrcInitia: false,
+        isDstInitia: true,
+        sender: "noble1sender",
+        recipient: "init1recipient",
       }),
     ).toBe(false)
   })
@@ -24,18 +24,18 @@ describe("shouldCheckExactFee", () => {
   it("returns false for initia-to-cosmos routes", () => {
     expect(
       shouldCheckExactFee({
-        isDstInitia: false,
-        recipient: "celestia1recipient",
         route: {
           required_op_hook: false,
         },
-        sender: "init1sender",
-        isSrcInitia: true,
         tx: {
           cosmos_tx: {
             msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
           },
         } as TxJson,
+        isSrcInitia: true,
+        isDstInitia: false,
+        sender: "init1sender",
+        recipient: "celestia1recipient",
       }),
     ).toBe(false)
   })
@@ -43,18 +43,18 @@ describe("shouldCheckExactFee", () => {
   it("returns true for initia-to-initia routes", () => {
     expect(
       shouldCheckExactFee({
-        isDstInitia: true,
-        recipient: "init1recipient",
         route: {
           required_op_hook: false,
         },
-        sender: "init1sender",
-        isSrcInitia: true,
         tx: {
           cosmos_tx: {
             msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
           },
         } as TxJson,
+        isSrcInitia: true,
+        isDstInitia: true,
+        sender: "init1sender",
+        recipient: "init1recipient",
       }),
     ).toBe(true)
   })

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
@@ -5,19 +5,19 @@ interface ExactFeeCheckRoute {
 }
 
 export function shouldCheckExactFee({
-  isDstInitia,
-  recipient,
   route,
-  sender,
-  isSrcInitia,
   tx,
+  isSrcInitia,
+  isDstInitia,
+  sender,
+  recipient,
 }: {
-  isDstInitia: boolean
-  recipient?: string
   route?: ExactFeeCheckRoute
-  sender?: string
-  isSrcInitia: boolean
   tx: TxJson
+  isSrcInitia: boolean
+  isDstInitia: boolean
+  sender?: string
+  recipient?: string
 }): boolean {
   return (
     !!route &&

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
@@ -12,11 +12,11 @@ export function shouldCheckExactFee({
   srcChainType,
   tx,
 }: {
-  dstChainType: string
+  dstChainType: ChainType
   recipient?: string
   route?: ExactFeeCheckRoute
   sender?: string
-  srcChainType: string
+  srcChainType: ChainType
   tx: TxJson
 }): boolean {
   return (

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
@@ -1,5 +1,7 @@
 import type { TxJson } from "@skip-go/client"
 
+type ChainType = "cosmos" | "evm" | "svm" | "initia"
+
 interface ExactFeeCheckRoute {
   required_op_hook?: boolean
 }

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
@@ -1,0 +1,71 @@
+import type { TxJson } from "@skip-go/client"
+import type { NormalizedChain } from "@/data/chains"
+
+interface ExactFeeCheckRoute {
+  amount_in: string
+  required_op_hook?: boolean
+}
+
+interface ExactFeeCheckSetup {
+  balanceKey: string
+}
+
+function getFeeBalanceKey({
+  balances,
+  feeDenoms,
+}: {
+  balances?: Record<string, { amount?: string }>
+  feeDenoms: string[]
+}): string {
+  if (!balances) return ""
+
+  return feeDenoms
+    .toSorted()
+    .map((denom) => `${denom}:${balances[denom]?.amount ?? "0"}`)
+    .join("|")
+}
+
+export function getExactFeeCheckSetup({
+  balances,
+  dstChainType,
+  findChain,
+  recipient,
+  route,
+  sender,
+  srcChainId,
+  srcChainType,
+  srcDenom,
+  tx,
+}: {
+  balances?: Record<string, { amount?: string }>
+  dstChainType: string
+  findChain: (chainId: string) => NormalizedChain
+  recipient?: string
+  route?: ExactFeeCheckRoute
+  sender?: string
+  srcChainId: string
+  srcChainType: string
+  srcDenom: string
+  tx: TxJson
+}): ExactFeeCheckSetup | null {
+  const requiresExactFeeCheck =
+    !!route &&
+    "cosmos_tx" in tx &&
+    !!tx.cosmos_tx.msgs?.length &&
+    !route.required_op_hook &&
+    srcChainType === "initia" &&
+    dstChainType === "initia" &&
+    !!sender &&
+    !!recipient
+
+  if (!requiresExactFeeCheck) return null
+
+  const chain = findChain(srcChainId)
+  const feeDenoms = Array.from(
+    new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)]),
+  )
+
+  return {
+    balanceKey: getFeeBalanceKey({ balances, feeDenoms }),
+  }
+}

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
@@ -1,24 +1,22 @@
 import type { TxJson } from "@skip-go/client"
 
-type ChainType = "cosmos" | "evm" | "svm" | "initia"
-
 interface ExactFeeCheckRoute {
   required_op_hook?: boolean
 }
 
 export function shouldCheckExactFee({
-  dstChainType,
+  isDstInitia,
   recipient,
   route,
   sender,
-  srcChainType,
+  isSrcInitia,
   tx,
 }: {
-  dstChainType: ChainType
+  isDstInitia: boolean
   recipient?: string
   route?: ExactFeeCheckRoute
   sender?: string
-  srcChainType: ChainType
+  isSrcInitia: boolean
   tx: TxJson
 }): boolean {
   return (
@@ -26,8 +24,8 @@ export function shouldCheckExactFee({
     "cosmos_tx" in tx &&
     !!tx.cosmos_tx.msgs?.length &&
     !route.required_op_hook &&
-    srcChainType === "initia" &&
-    dstChainType === "initia" &&
+    isSrcInitia &&
+    isDstInitia &&
     !!sender &&
     !!recipient
   )

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
@@ -30,3 +30,15 @@ export function shouldCheckExactFee({
     !!recipient
   )
 }
+
+export function shouldRunExactFeeQuery({
+  hasBalances,
+  hasChain,
+  requiresExactFeeCheck,
+}: {
+  hasBalances: boolean
+  hasChain: boolean
+  requiresExactFeeCheck: boolean
+}) {
+  return requiresExactFeeCheck && hasBalances && hasChain
+}

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
@@ -1,54 +1,25 @@
 import type { TxJson } from "@skip-go/client"
-import type { NormalizedChain } from "@/data/chains"
 
 interface ExactFeeCheckRoute {
-  amount_in: string
   required_op_hook?: boolean
 }
 
-interface ExactFeeCheckSetup {
-  balanceKey: string
-}
-
-function getFeeBalanceKey({
-  balances,
-  feeDenoms,
-}: {
-  balances?: Record<string, { amount?: string }>
-  feeDenoms: string[]
-}): string {
-  if (!balances) return ""
-
-  return feeDenoms
-    .toSorted()
-    .map((denom) => `${denom}:${balances[denom]?.amount ?? "0"}`)
-    .join("|")
-}
-
-export function getExactFeeCheckSetup({
-  balances,
+export function shouldCheckExactFee({
   dstChainType,
-  findChain,
   recipient,
   route,
   sender,
-  srcChainId,
   srcChainType,
-  srcDenom,
   tx,
 }: {
-  balances?: Record<string, { amount?: string }>
   dstChainType: string
-  findChain: (chainId: string) => NormalizedChain
   recipient?: string
   route?: ExactFeeCheckRoute
   sender?: string
-  srcChainId: string
   srcChainType: string
-  srcDenom: string
   tx: TxJson
-}): ExactFeeCheckSetup | null {
-  const requiresExactFeeCheck =
+}): boolean {
+  return (
     !!route &&
     "cosmos_tx" in tx &&
     !!tx.cosmos_tx.msgs?.length &&
@@ -57,15 +28,5 @@ export function getExactFeeCheckSetup({
     dstChainType === "initia" &&
     !!sender &&
     !!recipient
-
-  if (!requiresExactFeeCheck) return null
-
-  const chain = findChain(srcChainId)
-  const feeDenoms = Array.from(
-    new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)]),
   )
-
-  return {
-    balanceKey: getFeeBalanceKey({ balances, feeDenoms }),
-  }
 }


### PR DESCRIPTION
## Summary
- gate bridge preview exact-fee setup before resolving Initia registry metadata
- skip exact-fee checks for external source or destination chains instead of throwing `Chain not found`
- surface cold-start registry lookup failures from `useChainEnabled()` instead of leaving the exact-fee footer stuck in a loading state
- add regression coverage for external source, external destination, initia-to-initia, and registry-error paths

## Verification
- `pnpm --filter @initia/interwovenkit-react test`
- `pnpm --filter @initia/interwovenkit-react typecheck`

Fixes EXP-301

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/initia-labs/interwovenkit/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes when registry/balance queries run and how errors are surfaced in the bridge fee-check footer, which can affect UX and fee-validation behavior but doesn’t touch signing or on-chain transaction construction.
> 
> **Overview**
> Prevents bridge preview *exact-fee* checks from running for non-Initia routes and avoids throwing `Chain not found` by introducing explicit gating via `shouldCheckExactFee`/`shouldRunExactFeeQuery` and conditional chain lookups.
> 
> Refactors chain registry access to support enabled/disabled query behavior (`useChainEnabled` + `resolveEnabledChainState`) and to reuse a shared `createInitiaRegistryQueryOptions` path, with the footer now surfacing cold-start registry/balance errors instead of staying stuck loading.
> 
> Adds targeted unit coverage for the new gating and registry error/caching behavior (`chains.test.ts`, `exactFeeCheck.test.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d76dea8b1a6f08fc558c0cbedeac4a063b4ea560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->