### PR TITLE
fix(chains): separate deleted-chain display fallback

### DIFF
--- a/packages/interwovenkit-react/src/components/ExplorerLink.tsx
+++ b/packages/interwovenkit-react/src/components/ExplorerLink.tsx
@@ -23,11 +23,19 @@ const ExplorerLink = ({ chainId, txHash, accountAddress, pathSuffix, ...props }:
   const defaultText = txHash ? truncate(txHash) : accountAddress ? truncate(accountAddress) : ""
   const text = children ?? defaultText
 
-  // Filter out anchor-only attributes for span fallback
-  const { target, rel, download, ping, referrerPolicy, hrefLang, media, type, ...safeAttrs } = attrs
+  const spanAttrs = { ...attrs }
+  delete spanAttrs.href
+  delete spanAttrs.target
+  delete spanAttrs.rel
+  delete spanAttrs.download
+  delete spanAttrs.ping
+  delete spanAttrs.referrerPolicy
+  delete spanAttrs.hrefLang
+  delete spanAttrs.media
+  delete spanAttrs.type
 
   const renderFallback = () => (
-    <span {...safeAttrs} className={clsx(styles.link, className)}>
+    <span {...spanAttrs} className={clsx(styles.link, className)}>
       {text}
     </span>
   )

--- a/packages/interwovenkit-react/src/components/ExplorerLink.tsx
+++ b/packages/interwovenkit-react/src/components/ExplorerLink.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx"
 import xss from "xss"
 import { IconExternalLink } from "@initia/icons-react"
 import { truncate } from "@initia/utils"
-import { useChain } from "@/data/chains"
+import { isDeletedChain, useFindChainDisplay } from "@/data/chains"
 import { buildExplorerUrl, sanitizeLink } from "./explorer"
 import styles from "./ExplorerLink.module.css"
 
@@ -19,18 +19,30 @@ interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
 
 const ExplorerLink = ({ chainId, txHash, accountAddress, pathSuffix, ...props }: Props) => {
   const { showIcon, className, children, onClick, ...attrs } = props
-  const chain = useChain(chainId)
-
-  const url = buildExplorerUrl(chain, { txHash, accountAddress, pathSuffix })
+  const findChainDisplay = useFindChainDisplay()
   const defaultText = txHash ? truncate(txHash) : accountAddress ? truncate(accountAddress) : ""
   const text = children ?? defaultText
 
+  const renderFallback = () => (
+    <span {...attrs} className={clsx(styles.link, className)}>
+      {text}
+    </span>
+  )
+
+  let chain
+  try {
+    chain = findChainDisplay(chainId)
+  } catch {
+    return renderFallback()
+  }
+
+  if (isDeletedChain(chain)) {
+    return renderFallback()
+  }
+
+  const url = buildExplorerUrl(chain, { txHash, accountAddress, pathSuffix })
   if (!url) {
-    return (
-      <span {...attrs} className={clsx(styles.link, className)}>
-        {text}
-      </span>
-    )
+    return renderFallback()
   }
 
   return (

--- a/packages/interwovenkit-react/src/components/ExplorerLink.tsx
+++ b/packages/interwovenkit-react/src/components/ExplorerLink.tsx
@@ -23,8 +23,11 @@ const ExplorerLink = ({ chainId, txHash, accountAddress, pathSuffix, ...props }:
   const defaultText = txHash ? truncate(txHash) : accountAddress ? truncate(accountAddress) : ""
   const text = children ?? defaultText
 
+  // Filter out anchor-only attributes for span fallback
+  const { target, rel, download, ping, referrerPolicy, hrefLang, media, type, ...safeAttrs } = attrs
+
   const renderFallback = () => (
-    <span {...attrs} className={clsx(styles.link, className)}>
+    <span {...safeAttrs} className={clsx(styles.link, className)}>
       {text}
     </span>
   )

--- a/packages/interwovenkit-react/src/data/chains.test.ts
+++ b/packages/interwovenkit-react/src/data/chains.test.ts
@@ -1,0 +1,40 @@
+import type { NormalizedChain } from "./chains"
+import { resolveEnabledChainState } from "./chains"
+
+describe("resolveEnabledChainState", () => {
+  it("returns the query error when the registry fails before any data is cached", () => {
+    const error = new Error("Failed to load chains")
+
+    expect(
+      resolveEnabledChainState({
+        chainId: "initiation-1",
+        chains: undefined,
+        enabled: true,
+        error,
+        isLoading: false,
+      }),
+    ).toEqual({
+      chain: undefined,
+      error,
+      isLoading: false,
+    })
+  })
+
+  it("returns the cached chain even if a background refetch fails", () => {
+    const chain = { chain_id: "initiation-1" } as NormalizedChain
+
+    expect(
+      resolveEnabledChainState({
+        chainId: chain.chain_id,
+        chains: [chain],
+        enabled: true,
+        error: new Error("background refetch failed"),
+        isLoading: false,
+      }),
+    ).toEqual({
+      chain,
+      error: null,
+      isLoading: false,
+    })
+  })
+})

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -49,6 +49,22 @@ export function useInitiaRegistry() {
   return data
 }
 
+function useInitiaRegistryEnabled(enabled: boolean) {
+  const { defaultChainId, registryUrl, customChain } = useConfig()
+  return useQuery({
+    queryKey: chainQueryKeys.list(registryUrl).queryKey,
+    queryFn: () => ky.create({ prefixUrl: registryUrl }).get("chains.json").json<Chain[]>(),
+    select: (rawChains: Chain[]) => {
+      const chains = customChain
+        ? [customChain, ...rawChains.filter((chain) => chain.chain_id !== customChain.chain_id)]
+        : rawChains
+      return chains.map(normalizeChain).sort(descend((chain) => chain.chainId === defaultChainId))
+    },
+    staleTime: STALE_TIMES.MINUTE,
+    enabled,
+  })
+}
+
 export function useProfilesRegistry() {
   const { registryUrl } = useConfig()
   const { data } = useSuspenseQuery({
@@ -58,6 +74,17 @@ export function useProfilesRegistry() {
     staleTime: STALE_TIMES.MINUTE,
   })
   return data
+}
+
+function useProfilesRegistryEnabled(enabled: boolean) {
+  const { registryUrl } = useConfig()
+  return useQuery({
+    queryKey: chainQueryKeys.profiles(registryUrl).queryKey,
+    queryFn: () =>
+      ky.create({ prefixUrl: registryUrl }).get("profiles.json").json<ChainProfile[]>(),
+    staleTime: STALE_TIMES.MINUTE,
+    enabled,
+  })
 }
 
 export function useFindChain() {
@@ -95,6 +122,70 @@ export function useFindChain() {
 export function useChain(chainId: string) {
   const findChain = useFindChain()
   return findChain(chainId)
+}
+
+export function useChainEnabled(chainId: string, enabled: boolean) {
+  const chainsQuery = useInitiaRegistryEnabled(enabled)
+  const profilesQuery = useProfilesRegistryEnabled(enabled)
+
+  if (!enabled) {
+    return { chain: undefined, error: null, isLoading: false }
+  }
+
+  const queryError = chainsQuery.error ?? profilesQuery.error
+  if (queryError) {
+    return {
+      chain: undefined,
+      error: queryError instanceof Error ? queryError : new Error("Failed to load chains"),
+      isLoading: false,
+    }
+  }
+
+  if (chainsQuery.isLoading || profilesQuery.isLoading) {
+    return { chain: undefined, error: null, isLoading: true }
+  }
+
+  const chains = chainsQuery.data
+  const profiles = profilesQuery.data
+  if (!(chains && profiles)) {
+    return { chain: undefined, error: null, isLoading: true }
+  }
+
+  const chain = chains.find((chain) => chain.chain_id === chainId)
+  if (chain) {
+    return { chain, error: null, isLoading: false }
+  }
+
+  const profile = profiles.find((profile) => profile.chain_id === chainId)
+  if (!profile) {
+    return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
+  }
+
+  const layer1 = chains.find((chain) => chain.metadata?.is_l1)
+  if (!layer1) {
+    return { chain: undefined, error: new Error("Layer 1 not found"), isLoading: false }
+  }
+
+  return {
+    chain: {
+      chain_id: profile.chain_id,
+      chain_name: profile.name,
+      pretty_name: profile.pretty_name,
+      network_type: layer1.network_type,
+      bech32_prefix: "init" as const,
+      fees: { fee_tokens: [] },
+      apis: { rpc: [], rest: [], indexer: [] },
+      chainId,
+      name: profile.pretty_name,
+      logoUrl: profile.logo,
+      rpcUrl: "",
+      restUrl: "",
+      indexerUrl: "",
+      jsonRpcUrl: "",
+    } as NormalizedChain,
+    error: null,
+    isLoading: false,
+  }
 }
 
 export function useDefaultChain() {

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -32,6 +32,22 @@ function normalizeChain(chain: Chain) {
 }
 
 export type NormalizedChain = ReturnType<typeof normalizeChain>
+export interface DeletedChainFallback {
+  isDeleted: true
+  chain_id: string
+  chainId: string
+  chain_name: string
+  pretty_name: string
+  name: string
+  logoUrl: string
+  network_type: Chain["network_type"]
+}
+
+export type ResolvedChain = NormalizedChain | DeletedChainFallback
+
+export function isDeletedChain(chain: ResolvedChain): chain is DeletedChainFallback {
+  return "isDeleted" in chain
+}
 
 export function resolveEnabledChainState({
   chainId,
@@ -122,10 +138,19 @@ export function useProfilesRegistry() {
 }
 
 export function useFindChain() {
+  const chains = useInitiaRegistry()
+  return (chainId: string): NormalizedChain => {
+    const chain = chains.find((chain) => chain.chain_id === chainId)
+    if (chain) return chain
+    throw new Error(`Chain not found in active registry: ${chainId}`)
+  }
+}
+
+export function useFindChainDisplay() {
   const layer1 = useLayer1()
   const chains = useInitiaRegistry()
   const profiles = useProfilesRegistry()
-  return (chainId: string) => {
+  return (chainId: string): ResolvedChain => {
     const chain = chains.find((chain) => chain.chain_id === chainId)
     if (chain) return chain
 
@@ -133,23 +158,18 @@ export function useFindChain() {
     const profile = profiles.find((profile) => profile.chain_id === chainId)
     if (!profile) throw new Error(`Chain not found: ${chainId}`)
 
-    // Return a minimal chain object with display metadata from profile
+    // Return a display-only fallback and force call sites to narrow before
+    // accessing endpoint/metadata fields from NormalizedChain.
     return {
-      chain_id: profile.chain_id,
-      chain_name: profile.name,
-      pretty_name: profile.pretty_name,
-      network_type: layer1.network_type,
-      bech32_prefix: "init" as const,
-      fees: { fee_tokens: [] },
-      apis: { rpc: [], rest: [], indexer: [] },
+      isDeleted: true,
+      chain_id: profile.chain_id ?? chainId,
       chainId,
-      name: profile.pretty_name,
-      logoUrl: profile.logo,
-      rpcUrl: "",
-      restUrl: "",
-      indexerUrl: "",
-      jsonRpcUrl: "",
-    } as NormalizedChain
+      chain_name: profile.name ?? chainId,
+      pretty_name: profile.pretty_name ?? profile.name ?? chainId,
+      name: profile.pretty_name ?? profile.name ?? chainId,
+      logoUrl: profile.logo ?? "",
+      network_type: layer1.network_type,
+    }
   }
 }
 

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -33,6 +33,51 @@ function normalizeChain(chain: Chain) {
 
 export type NormalizedChain = ReturnType<typeof normalizeChain>
 
+export function resolveEnabledChainState({
+  chainId,
+  chains,
+  enabled,
+  error,
+  isLoading,
+}: {
+  chainId: string
+  chains?: NormalizedChain[]
+  enabled: boolean
+  error: unknown
+  isLoading: boolean
+}) {
+  if (!enabled) {
+    return { chain: undefined, error: null, isLoading: false }
+  }
+
+  const chain = chains?.find((chain) => chain.chain_id === chainId)
+  if (chain) {
+    return { chain, error: null, isLoading: false }
+  }
+
+  if (error && !chains) {
+    return {
+      chain: undefined,
+      error: error instanceof Error ? error : new Error("Failed to load chains"),
+      isLoading: false,
+    }
+  }
+
+  if (isLoading || !chains) {
+    return { chain: undefined, error: null, isLoading: true }
+  }
+
+  if (error) {
+    return {
+      chain: undefined,
+      error: error instanceof Error ? error : new Error("Failed to load chains"),
+      isLoading: false,
+    }
+  }
+
+  return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
+}
+
 export function useInitiaRegistry() {
   const { defaultChainId, registryUrl, customChain } = useConfig()
   const { data } = useSuspenseQuery({
@@ -115,35 +160,13 @@ export function useChain(chainId: string) {
 
 export function useChainEnabled(chainId: string, enabled: boolean) {
   const chainsQuery = useInitiaRegistryEnabled(enabled)
-
-  if (!enabled) {
-    return { chain: undefined, error: null, isLoading: false }
-  }
-
-  if (chainsQuery.isLoading && !chainsQuery.data) {
-    return { chain: undefined, error: null, isLoading: true }
-  }
-
-  const chains = chainsQuery.data
-  if (!chains) {
-    return { chain: undefined, error: null, isLoading: true }
-  }
-
-  const chain = chains.find((chain) => chain.chain_id === chainId)
-  if (chain) {
-    return { chain, error: null, isLoading: false }
-  }
-
-  if (chainsQuery.error) {
-    return {
-      chain: undefined,
-      error:
-        chainsQuery.error instanceof Error ? chainsQuery.error : new Error("Failed to load chains"),
-      isLoading: false,
-    }
-  }
-
-  return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
+  return resolveEnabledChainState({
+    chainId,
+    chains: chainsQuery.data,
+    enabled,
+    error: chainsQuery.error,
+    isLoading: chainsQuery.isLoading,
+  })
 }
 
 export function useDefaultChain() {

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -76,17 +76,6 @@ export function useProfilesRegistry() {
   return data
 }
 
-function useProfilesRegistryEnabled(enabled: boolean) {
-  const { registryUrl } = useConfig()
-  return useQuery({
-    queryKey: chainQueryKeys.profiles(registryUrl).queryKey,
-    queryFn: () =>
-      ky.create({ prefixUrl: registryUrl }).get("profiles.json").json<ChainProfile[]>(),
-    staleTime: STALE_TIMES.MINUTE,
-    enabled,
-  })
-}
-
 export function useFindChain() {
   const layer1 = useLayer1()
   const chains = useInitiaRegistry()
@@ -126,22 +115,12 @@ export function useChain(chainId: string) {
 
 export function useChainEnabled(chainId: string, enabled: boolean) {
   const chainsQuery = useInitiaRegistryEnabled(enabled)
-  const profilesQuery = useProfilesRegistryEnabled(enabled)
 
   if (!enabled) {
     return { chain: undefined, error: null, isLoading: false }
   }
 
-  if (chainsQuery.error) {
-    return {
-      chain: undefined,
-      error:
-        chainsQuery.error instanceof Error ? chainsQuery.error : new Error("Failed to load chains"),
-      isLoading: false,
-    }
-  }
-
-  if (chainsQuery.isLoading) {
+  if (chainsQuery.isLoading && !chainsQuery.data) {
     return { chain: undefined, error: null, isLoading: true }
   }
 
@@ -155,56 +134,16 @@ export function useChainEnabled(chainId: string, enabled: boolean) {
     return { chain, error: null, isLoading: false }
   }
 
-  if (profilesQuery.error) {
+  if (chainsQuery.error) {
     return {
       chain: undefined,
       error:
-        profilesQuery.error instanceof Error
-          ? profilesQuery.error
-          : new Error("Failed to load chains"),
+        chainsQuery.error instanceof Error ? chainsQuery.error : new Error("Failed to load chains"),
       isLoading: false,
     }
   }
 
-  if (profilesQuery.isLoading) {
-    return { chain: undefined, error: null, isLoading: true }
-  }
-
-  const profiles = profilesQuery.data
-  if (!profiles) {
-    return { chain: undefined, error: null, isLoading: true }
-  }
-
-  const profile = profiles.find((profile) => profile.chain_id === chainId)
-  if (!profile) {
-    return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
-  }
-
-  const layer1 = chains.find((chain) => chain.metadata?.is_l1)
-  if (!layer1) {
-    return { chain: undefined, error: new Error("Layer 1 not found"), isLoading: false }
-  }
-
-  return {
-    chain: {
-      chain_id: profile.chain_id,
-      chain_name: profile.name,
-      pretty_name: profile.pretty_name,
-      network_type: layer1.network_type,
-      bech32_prefix: "init" as const,
-      fees: { fee_tokens: [] },
-      apis: { rpc: [], rest: [], indexer: [] },
-      chainId,
-      name: profile.pretty_name,
-      logoUrl: profile.logo,
-      rpcUrl: "",
-      restUrl: "",
-      indexerUrl: "",
-      jsonRpcUrl: "",
-    } as NormalizedChain,
-    error: null,
-    isLoading: false,
-  }
+  return { chain: undefined, error: new Error(`Chain not found: ${chainId}`), isLoading: false }
 }
 
 export function useDefaultChain() {

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -49,6 +49,10 @@ export function isDeletedChain(chain: ResolvedChain): chain is DeletedChainFallb
   return "isDeleted" in chain
 }
 
+function toLoadChainsError(error: unknown) {
+  return error instanceof Error ? error : new Error(`Failed to load chains: ${String(error)}`)
+}
+
 export function resolveEnabledChainState({
   chainId,
   chains,
@@ -74,7 +78,7 @@ export function resolveEnabledChainState({
   if (error && !chains) {
     return {
       chain: undefined,
-      error: error instanceof Error ? error : new Error("Failed to load chains"),
+      error: toLoadChainsError(error),
       isLoading: false,
     }
   }
@@ -86,7 +90,7 @@ export function resolveEnabledChainState({
   if (error) {
     return {
       chain: undefined,
-      error: error instanceof Error ? error : new Error("Failed to load chains"),
+      error: toLoadChainsError(error),
       isLoading: false,
     }
   }
@@ -156,18 +160,17 @@ export function useFindChainDisplay() {
 
     // Fallback to profiles.json for deleted chains
     const profile = profiles.find((profile) => profile.chain_id === chainId)
-    if (!profile) throw new Error(`Chain not found: ${chainId}`)
 
     // Return a display-only fallback and force call sites to narrow before
     // accessing endpoint/metadata fields from NormalizedChain.
     return {
       isDeleted: true,
-      chain_id: profile.chain_id ?? chainId,
+      chain_id: profile?.chain_id ?? chainId,
       chainId,
-      chain_name: profile.name ?? chainId,
-      pretty_name: profile.pretty_name ?? profile.name ?? chainId,
-      name: profile.pretty_name ?? profile.name ?? chainId,
-      logoUrl: profile.logo ?? "",
+      chain_name: profile?.name ?? chainId,
+      pretty_name: profile?.pretty_name ?? profile?.name ?? chainId,
+      name: profile?.pretty_name ?? profile?.name ?? chainId,
+      logoUrl: profile?.logo ?? "",
       network_type: layer1.network_type,
     }
   }

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -132,28 +132,47 @@ export function useChainEnabled(chainId: string, enabled: boolean) {
     return { chain: undefined, error: null, isLoading: false }
   }
 
-  const queryError = chainsQuery.error ?? profilesQuery.error
-  if (queryError) {
+  if (chainsQuery.error) {
     return {
       chain: undefined,
-      error: queryError instanceof Error ? queryError : new Error("Failed to load chains"),
+      error:
+        chainsQuery.error instanceof Error ? chainsQuery.error : new Error("Failed to load chains"),
       isLoading: false,
     }
   }
 
-  if (chainsQuery.isLoading || profilesQuery.isLoading) {
+  if (chainsQuery.isLoading) {
     return { chain: undefined, error: null, isLoading: true }
   }
 
   const chains = chainsQuery.data
-  const profiles = profilesQuery.data
-  if (!(chains && profiles)) {
+  if (!chains) {
     return { chain: undefined, error: null, isLoading: true }
   }
 
   const chain = chains.find((chain) => chain.chain_id === chainId)
   if (chain) {
     return { chain, error: null, isLoading: false }
+  }
+
+  if (profilesQuery.error) {
+    return {
+      chain: undefined,
+      error:
+        profilesQuery.error instanceof Error
+          ? profilesQuery.error
+          : new Error("Failed to load chains"),
+      isLoading: false,
+    }
+  }
+
+  if (profilesQuery.isLoading) {
+    return { chain: undefined, error: null, isLoading: true }
+  }
+
+  const profiles = profilesQuery.data
+  if (!profiles) {
+    return { chain: undefined, error: null, isLoading: true }
   }
 
   const profile = profiles.find((profile) => profile.chain_id === chainId)

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -1,13 +1,13 @@
 import type { TxJson } from "@skip-go/client"
-import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { useChain } from "@/data/chains"
+import { useFindChain } from "@/data/chains"
 import { fetchGasPrices } from "@/data/fee"
 import { normalizeError } from "@/data/http"
 import { useAminoConverters, useAminoTypes, useCreateSigningStargateClient } from "@/data/signer"
 import { useSkipBalancesQuery } from "./data/balance"
 import { computeRequiredFeeByDenom, hasSufficientFeeBalance } from "./data/bridgeTxUtils"
 import { useChainType, useSkipChain } from "./data/chains"
+import { getExactFeeCheckSetup } from "./data/exactFeeCheck"
 import { decodeCosmosAminoMessages, useBridgePreviewState } from "./data/tx"
 
 import type { ReactNode } from "react"
@@ -17,25 +17,10 @@ interface Props {
   children: (status: { exactFeeCheckError?: string; isCheckingFeeBalance: boolean }) => ReactNode
 }
 
-function getFeeBalanceKey({
-  balances,
-  feeDenoms,
-}: {
-  balances?: Record<string, { amount?: string }>
-  feeDenoms: string[]
-}): string {
-  if (!balances) return ""
-
-  return feeDenoms
-    .toSorted()
-    .map((denom) => `${denom}:${balances[denom]?.amount ?? "0"}`)
-    .join("|")
-}
-
 function FooterWithExactFeeCheck({ tx, children }: Props) {
   const { route, values } = useBridgePreviewState()
   const { sender, recipient, srcChainId, srcDenom, dstChainId } = values
-  const chain = useChain(srcChainId)
+  const findChain = useFindChain()
   const srcChain = useSkipChain(srcChainId)
   const dstChain = useSkipChain(dstChainId)
   const srcChainType = useChainType(srcChain)
@@ -48,20 +33,18 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
   const aminoConverters = useAminoConverters()
   const aminoTypes = useAminoTypes()
   const createSigningStargateClient = useCreateSigningStargateClient()
-  const feeDenoms = useMemo(
-    () => Array.from(new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)])),
-    [chain.fees.fee_tokens, srcDenom],
-  )
-  const balanceKey = useMemo(() => getFeeBalanceKey({ balances, feeDenoms }), [balances, feeDenoms])
-
-  const requiresExactFeeCheck =
-    "cosmos_tx" in tx &&
-    !!tx.cosmos_tx.msgs?.length &&
-    !route.required_op_hook &&
-    srcChainType === "initia" &&
-    dstChainType === "initia" &&
-    !!sender &&
-    !!recipient
+  const exactFeeCheck = getExactFeeCheckSetup({
+    balances,
+    dstChainType,
+    findChain,
+    recipient,
+    route,
+    sender,
+    srcChainId,
+    srcChainType,
+    srcDenom,
+    tx,
+  })
 
   const {
     data: hasFeeBalance,
@@ -75,11 +58,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
       srcChainId,
       srcDenom,
       route.amount_in,
-      balanceKey,
+      exactFeeCheck?.balanceKey,
     ],
     queryFn: async () => {
       try {
-        if (!("cosmos_tx" in tx) || !tx.cosmos_tx.msgs?.length || !balances) {
+        if (!(exactFeeCheck && "cosmos_tx" in tx && tx.cosmos_tx.msgs?.length && balances)) {
           throw new Error("Invalid transaction data")
         }
 
@@ -89,7 +72,7 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
         })
         const client = await createSigningStargateClient(srcChainId)
         const gas = await client.simulate(sender, messages, "")
-        const gasPrices = await fetchGasPrices(chain)
+        const gasPrices = await fetchGasPrices(findChain(srcChainId))
         const requiredFeeByDenom = computeRequiredFeeByDenom({
           gas,
           gasPrices,
@@ -105,11 +88,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
         throw await normalizeError(error)
       }
     },
-    enabled: requiresExactFeeCheck && balances !== undefined,
+    enabled: !!exactFeeCheck && balances !== undefined,
     retry: false,
   })
 
-  if (!requiresExactFeeCheck) {
+  if (!exactFeeCheck) {
     return children({ isCheckingFeeBalance: false })
   }
 

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -1,6 +1,6 @@
 import type { TxJson } from "@skip-go/client"
 import { useQuery } from "@tanstack/react-query"
-import { useFindChain } from "@/data/chains"
+import { useChainEnabled } from "@/data/chains"
 import { fetchGasPrices } from "@/data/fee"
 import { normalizeError } from "@/data/http"
 import { useAminoConverters, useAminoTypes, useCreateSigningStargateClient } from "@/data/signer"
@@ -35,7 +35,6 @@ function getFeeBalanceKey({
 function FooterWithExactFeeCheck({ tx, children }: Props) {
   const { route, values } = useBridgePreviewState()
   const { sender, recipient, srcChainId, srcDenom, dstChainId } = values
-  const findChain = useFindChain()
   const srcChain = useSkipChain(srcChainId)
   const dstChain = useSkipChain(dstChainId)
   const srcChainType = useChainType(srcChain)
@@ -56,7 +55,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
     srcChainType,
     tx,
   })
-  const chain = requiresExactFeeCheck ? findChain(srcChainId) : undefined
+  const {
+    chain,
+    error: chainError,
+    isLoading: isLoadingChain,
+  } = useChainEnabled(srcChainId, requiresExactFeeCheck)
   const feeDenoms = chain
     ? Array.from(new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)]))
     : []
@@ -120,6 +123,10 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
     return children({ isCheckingFeeBalance: false })
   }
 
+  if (chainError) {
+    return children({ exactFeeCheckError: chainError.message, isCheckingFeeBalance: false })
+  }
+
   if (balancesError) {
     return children({
       exactFeeCheckError: "Failed to load balances",
@@ -127,7 +134,7 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
     })
   }
 
-  if (isLoadingBalances || balances === undefined || isLoading) {
+  if (isLoadingChain || isLoadingBalances || balances === undefined || isLoading) {
     return children({ isCheckingFeeBalance: true })
   }
 

--- a/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/FooterWithExactFeeCheck.tsx
@@ -7,7 +7,7 @@ import { useAminoConverters, useAminoTypes, useCreateSigningStargateClient } fro
 import { useSkipBalancesQuery } from "./data/balance"
 import { computeRequiredFeeByDenom, hasSufficientFeeBalance } from "./data/bridgeTxUtils"
 import { useChainType, useSkipChain } from "./data/chains"
-import { getExactFeeCheckSetup } from "./data/exactFeeCheck"
+import { shouldCheckExactFee } from "./data/exactFeeCheck"
 import { decodeCosmosAminoMessages, useBridgePreviewState } from "./data/tx"
 
 import type { ReactNode } from "react"
@@ -15,6 +15,21 @@ import type { ReactNode } from "react"
 interface Props {
   tx: TxJson
   children: (status: { exactFeeCheckError?: string; isCheckingFeeBalance: boolean }) => ReactNode
+}
+
+function getFeeBalanceKey({
+  balances,
+  feeDenoms,
+}: {
+  balances?: Record<string, { amount?: string }>
+  feeDenoms: string[]
+}): string {
+  if (!balances) return ""
+
+  return feeDenoms
+    .toSorted()
+    .map((denom) => `${denom}:${balances[denom]?.amount ?? "0"}`)
+    .join("|")
 }
 
 function FooterWithExactFeeCheck({ tx, children }: Props) {
@@ -33,18 +48,19 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
   const aminoConverters = useAminoConverters()
   const aminoTypes = useAminoTypes()
   const createSigningStargateClient = useCreateSigningStargateClient()
-  const exactFeeCheck = getExactFeeCheckSetup({
-    balances,
+  const requiresExactFeeCheck = shouldCheckExactFee({
     dstChainType,
-    findChain,
     recipient,
     route,
     sender,
-    srcChainId,
     srcChainType,
-    srcDenom,
     tx,
   })
+  const chain = requiresExactFeeCheck ? findChain(srcChainId) : undefined
+  const feeDenoms = chain
+    ? Array.from(new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)]))
+    : []
+  const balanceKey = getFeeBalanceKey({ balances, feeDenoms })
 
   const {
     data: hasFeeBalance,
@@ -58,11 +74,19 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
       srcChainId,
       srcDenom,
       route.amount_in,
-      exactFeeCheck?.balanceKey,
+      balanceKey,
     ],
     queryFn: async () => {
       try {
-        if (!(exactFeeCheck && "cosmos_tx" in tx && tx.cosmos_tx.msgs?.length && balances)) {
+        if (
+          !(
+            requiresExactFeeCheck &&
+            chain &&
+            "cosmos_tx" in tx &&
+            tx.cosmos_tx.msgs?.length &&
+            balances
+          )
+        ) {
           throw new Error("Invalid transaction data")
         }
 
@@ -72,7 +96,7 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
         })
         const client = await createSigningStargateClient(srcChainId)
         const gas = await client.simulate(sender, messages, "")
-        const gasPrices = await fetchGasPrices(findChain(srcChainId))
+        const gasPrices = await fetchGasPrices(chain)
         const requiredFeeByDenom = computeRequiredFeeByDenom({
           gas,
           gasPrices,
@@ -88,11 +112,11 @@ function FooterWithExactFeeCheck({ tx, children }: Props) {
         throw await normalizeError(error)
       }
     },
-    enabled: !!exactFeeCheck && balances !== undefined,
+    enabled: requiresExactFeeCheck && balances !== undefined,
     retry: false,
   })
 
-  if (!exactFeeCheck) {
+  if (!requiresExactFeeCheck) {
     return children({ isCheckingFeeBalance: false })
   }
 

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
@@ -65,7 +65,7 @@ describe("getExactFeeCheckSetup", () => {
     expect(findChain).not.toHaveBeenCalled()
   })
 
-  it("builds fee context for initia cosmos routes", () => {
+  it("builds fee context for initia-to-initia routes", () => {
     const findChain = vi.fn(
       () =>
         ({

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
@@ -1,106 +1,61 @@
 import type { TxJson } from "@skip-go/client"
-import type { NormalizedChain } from "@/data/chains"
-import { getExactFeeCheckSetup } from "./exactFeeCheck"
+import { shouldCheckExactFee } from "./exactFeeCheck"
 
-describe("getExactFeeCheckSetup", () => {
-  it("skips external routes without resolving initia registry chains", () => {
-    const findChain = vi.fn(() => {
-      throw new Error("should not resolve initia chain")
-    })
-
-    const result = getExactFeeCheckSetup({
-      balances: {
-        uusdc: { amount: "1000" },
-      },
-      dstChainType: "initia",
-      findChain,
-      recipient: "init1recipient",
-      route: {
-        amount_in: "100",
-        required_op_hook: false,
-      },
-      sender: "noble1sender",
-      srcChainId: "noble-1",
-      srcChainType: "cosmos",
-      srcDenom: "uusdc",
-      tx: {
-        cosmos_tx: {
-          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+describe("shouldCheckExactFee", () => {
+  it("returns false for cosmos-to-initia routes", () => {
+    expect(
+      shouldCheckExactFee({
+        dstChainType: "initia",
+        recipient: "init1recipient",
+        route: {
+          required_op_hook: false,
         },
-      } as TxJson,
-    })
-
-    expect(result).toBeNull()
-    expect(findChain).not.toHaveBeenCalled()
-  })
-
-  it("skips initia routes when the destination chain is external", () => {
-    const findChain = vi.fn(() => {
-      throw new Error("should not resolve initia chain")
-    })
-
-    const result = getExactFeeCheckSetup({
-      balances: {
-        uinit: { amount: "1000" },
-      },
-      dstChainType: "cosmos",
-      findChain,
-      recipient: "celestia1recipient",
-      route: {
-        amount_in: "100",
-        required_op_hook: false,
-      },
-      sender: "init1sender",
-      srcChainId: "initia-1",
-      srcChainType: "initia",
-      srcDenom: "uinit",
-      tx: {
-        cosmos_tx: {
-          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
-        },
-      } as TxJson,
-    })
-
-    expect(result).toBeNull()
-    expect(findChain).not.toHaveBeenCalled()
-  })
-
-  it("builds fee context for initia-to-initia routes", () => {
-    const findChain = vi.fn(
-      () =>
-        ({
-          fees: {
-            fee_tokens: [{ denom: "uinit" }, { denom: "uusdc" }],
+        sender: "noble1sender",
+        srcChainType: "cosmos",
+        tx: {
+          cosmos_tx: {
+            msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
           },
-        }) as NormalizedChain,
-    )
+        } as TxJson,
+      }),
+    ).toBe(false)
+  })
 
-    const result = getExactFeeCheckSetup({
-      balances: {
-        uinit: { amount: "2000" },
-        uusdc: { amount: "500" },
-      },
-      dstChainType: "initia",
-      findChain,
-      recipient: "init1recipient",
-      route: {
-        amount_in: "100",
-        required_op_hook: false,
-      },
-      sender: "init1sender",
-      srcChainId: "initia-1",
-      srcChainType: "initia",
-      srcDenom: "uinit",
-      tx: {
-        cosmos_tx: {
-          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+  it("returns false for initia-to-cosmos routes", () => {
+    expect(
+      shouldCheckExactFee({
+        dstChainType: "cosmos",
+        recipient: "celestia1recipient",
+        route: {
+          required_op_hook: false,
         },
-      } as TxJson,
-    })
+        sender: "init1sender",
+        srcChainType: "initia",
+        tx: {
+          cosmos_tx: {
+            msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+          },
+        } as TxJson,
+      }),
+    ).toBe(false)
+  })
 
-    expect(findChain).toHaveBeenCalledWith("initia-1")
-    expect(result).toEqual({
-      balanceKey: "uinit:2000|uusdc:500",
-    })
+  it("returns true for initia-to-initia routes", () => {
+    expect(
+      shouldCheckExactFee({
+        dstChainType: "initia",
+        recipient: "init1recipient",
+        route: {
+          required_op_hook: false,
+        },
+        sender: "init1sender",
+        srcChainType: "initia",
+        tx: {
+          cosmos_tx: {
+            msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+          },
+        } as TxJson,
+      }),
+    ).toBe(true)
   })
 })

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.test.ts
@@ -1,0 +1,106 @@
+import type { TxJson } from "@skip-go/client"
+import type { NormalizedChain } from "@/data/chains"
+import { getExactFeeCheckSetup } from "./exactFeeCheck"
+
+describe("getExactFeeCheckSetup", () => {
+  it("skips external routes without resolving initia registry chains", () => {
+    const findChain = vi.fn(() => {
+      throw new Error("should not resolve initia chain")
+    })
+
+    const result = getExactFeeCheckSetup({
+      balances: {
+        uusdc: { amount: "1000" },
+      },
+      dstChainType: "initia",
+      findChain,
+      recipient: "init1recipient",
+      route: {
+        amount_in: "100",
+        required_op_hook: false,
+      },
+      sender: "noble1sender",
+      srcChainId: "noble-1",
+      srcChainType: "cosmos",
+      srcDenom: "uusdc",
+      tx: {
+        cosmos_tx: {
+          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+        },
+      } as TxJson,
+    })
+
+    expect(result).toBeNull()
+    expect(findChain).not.toHaveBeenCalled()
+  })
+
+  it("skips initia routes when the destination chain is external", () => {
+    const findChain = vi.fn(() => {
+      throw new Error("should not resolve initia chain")
+    })
+
+    const result = getExactFeeCheckSetup({
+      balances: {
+        uinit: { amount: "1000" },
+      },
+      dstChainType: "cosmos",
+      findChain,
+      recipient: "celestia1recipient",
+      route: {
+        amount_in: "100",
+        required_op_hook: false,
+      },
+      sender: "init1sender",
+      srcChainId: "initia-1",
+      srcChainType: "initia",
+      srcDenom: "uinit",
+      tx: {
+        cosmos_tx: {
+          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+        },
+      } as TxJson,
+    })
+
+    expect(result).toBeNull()
+    expect(findChain).not.toHaveBeenCalled()
+  })
+
+  it("builds fee context for initia cosmos routes", () => {
+    const findChain = vi.fn(
+      () =>
+        ({
+          fees: {
+            fee_tokens: [{ denom: "uinit" }, { denom: "uusdc" }],
+          },
+        }) as NormalizedChain,
+    )
+
+    const result = getExactFeeCheckSetup({
+      balances: {
+        uinit: { amount: "2000" },
+        uusdc: { amount: "500" },
+      },
+      dstChainType: "initia",
+      findChain,
+      recipient: "init1recipient",
+      route: {
+        amount_in: "100",
+        required_op_hook: false,
+      },
+      sender: "init1sender",
+      srcChainId: "initia-1",
+      srcChainType: "initia",
+      srcDenom: "uinit",
+      tx: {
+        cosmos_tx: {
+          msgs: [{ msg_type_url: "/cosmos.bank.v1beta1.MsgSend", msg: "{}" }],
+        },
+      } as TxJson,
+    })
+
+    expect(findChain).toHaveBeenCalledWith("initia-1")
+    expect(result).toEqual({
+      balanceKey: "uinit:2000|uusdc:500",
+    })
+  })
+})

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
@@ -1,0 +1,71 @@
+import type { TxJson } from "@skip-go/client"
+import type { NormalizedChain } from "@/data/chains"
+
+interface ExactFeeCheckRoute {
+  amount_in: string
+  required_op_hook?: boolean
+}
+
+interface ExactFeeCheckSetup {
+  balanceKey: string
+}
+
+function getFeeBalanceKey({
+  balances,
+  feeDenoms,
+}: {
+  balances?: Record<string, { amount?: string }>
+  feeDenoms: string[]
+}): string {
+  if (!balances) return ""
+
+  return feeDenoms
+    .toSorted()
+    .map((denom) => `${denom}:${balances[denom]?.amount ?? "0"}`)
+    .join("|")
+}
+
+export function getExactFeeCheckSetup({
+  balances,
+  dstChainType,
+  findChain,
+  recipient,
+  route,
+  sender,
+  srcChainId,
+  srcChainType,
+  srcDenom,
+  tx,
+}: {
+  balances?: Record<string, { amount?: string }>
+  dstChainType: string
+  findChain: (chainId: string) => NormalizedChain
+  recipient?: string
+  route?: ExactFeeCheckRoute
+  sender?: string
+  srcChainId: string
+  srcChainType: string
+  srcDenom: string
+  tx: TxJson
+}): ExactFeeCheckSetup | null {
+  const requiresExactFeeCheck =
+    !!route &&
+    "cosmos_tx" in tx &&
+    !!tx.cosmos_tx.msgs?.length &&
+    !route.required_op_hook &&
+    srcChainType === "initia" &&
+    dstChainType === "initia" &&
+    !!sender &&
+    !!recipient
+
+  if (!requiresExactFeeCheck) return null
+
+  const chain = findChain(srcChainId)
+  const feeDenoms = Array.from(
+    new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)]),
+  )
+
+  return {
+    balanceKey: getFeeBalanceKey({ balances, feeDenoms }),
+  }
+}

--- a/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/exactFeeCheck.ts
@@ -1,54 +1,25 @@
 import type { TxJson } from "@skip-go/client"
-import type { NormalizedChain } from "@/data/chains"
 
 interface ExactFeeCheckRoute {
-  amount_in: string
   required_op_hook?: boolean
 }
 
-interface ExactFeeCheckSetup {
-  balanceKey: string
-}
-
-function getFeeBalanceKey({
-  balances,
-  feeDenoms,
-}: {
-  balances?: Record<string, { amount?: string }>
-  feeDenoms: string[]
-}): string {
-  if (!balances) return ""
-
-  return feeDenoms
-    .toSorted()
-    .map((denom) => `${denom}:${balances[denom]?.amount ?? "0"}`)
-    .join("|")
-}
-
-export function getExactFeeCheckSetup({
-  balances,
+export function shouldCheckExactFee({
   dstChainType,
-  findChain,
   recipient,
   route,
   sender,
-  srcChainId,
   srcChainType,
-  srcDenom,
   tx,
 }: {
-  balances?: Record<string, { amount?: string }>
   dstChainType: string
-  findChain: (chainId: string) => NormalizedChain
   recipient?: string
   route?: ExactFeeCheckRoute
   sender?: string
-  srcChainId: string
   srcChainType: string
-  srcDenom: string
   tx: TxJson
-}): ExactFeeCheckSetup | null {
-  const requiresExactFeeCheck =
+}): boolean {
+  return (
     !!route &&
     "cosmos_tx" in tx &&
     !!tx.cosmos_tx.msgs?.length &&
@@ -57,15 +28,5 @@ export function getExactFeeCheckSetup({
     dstChainType === "initia" &&
     !!sender &&
     !!recipient
-
-  if (!requiresExactFeeCheck) return null
-
-  const chain = findChain(srcChainId)
-  const feeDenoms = Array.from(
-    new Set([srcDenom, ...chain.fees.fee_tokens.map(({ denom }) => denom)]),
   )
-
-  return {
-    balanceKey: getFeeBalanceKey({ balances, feeDenoms }),
-  }
 }

--- a/packages/interwovenkit-react/src/pages/bridge/op/ClaimableList.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/op/ClaimableList.tsx
@@ -2,7 +2,7 @@ import { formatAmount } from "@initia/utils"
 import Image from "@/components/Image"
 import PlainModalContent from "@/components/PlainModalContent"
 import { useFindAsset } from "@/data/assets"
-import { useFindChain, useLayer1 } from "@/data/chains"
+import { useFindChainDisplay, useLayer1 } from "@/data/chains"
 import type { ReminderDetails } from "./reminder"
 import styles from "./ClaimableList.module.css"
 
@@ -14,7 +14,7 @@ interface Props {
 
 const ClaimableList = ({ list, onNavigate, onDismiss }: Props) => {
   const layer1 = useLayer1()
-  const findChain = useFindChain()
+  const findChain = useFindChainDisplay()
   const findAsset = useFindAsset(layer1)
 
   return (

--- a/packages/interwovenkit-react/src/pages/bridge/op/Withdrawals.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/op/Withdrawals.tsx
@@ -3,7 +3,12 @@ import AsyncBoundary from "@/components/AsyncBoundary"
 import ChainOptions from "@/components/form/ChainOptions"
 import FormHelp from "@/components/form/FormHelp"
 import Page from "@/components/Page"
-import { useDefaultChain, useFindChain, useInitiaRegistry } from "@/data/chains"
+import {
+  isDeletedChain,
+  useDefaultChain,
+  useFindChainDisplay,
+  useInitiaRegistry,
+} from "@/data/chains"
 import { useLocationState } from "@/lib/router"
 import { useClaimableReminders } from "./reminder"
 import WithdrawalList from "./WithdrawalList"
@@ -16,7 +21,7 @@ const Withdrawals = () => {
   const [chainId, setChainId] = useState(
     initialChainId ?? (defaultChain.metadata?.is_l1 ? "" : defaultChain.chainId),
   )
-  const findChain = useFindChain()
+  const findChain = useFindChainDisplay()
   const { reminders } = useClaimableReminders()
   const chain = chainId ? findChain(chainId) : undefined
 
@@ -32,6 +37,10 @@ const Withdrawals = () => {
       <div className={styles.content}>
         {!chain ? (
           <FormHelp level="info">Select a chain to display your OP Bridge withdrawals</FormHelp>
+        ) : isDeletedChain(chain) ? (
+          <FormHelp level="info">
+            {chain.name} is no longer available for OP Bridge withdrawals
+          </FormHelp>
         ) : (
           <>
             <h2 className={styles.title}>{chain.name}</h2>


### PR DESCRIPTION
## Summary
- separate deleted-chain display fallbacks from active Initia registry lookups
- introduce a display-only deleted-chain type so callers must narrow before accessing endpoint metadata
- update OP withdrawal history surfaces to handle deleted chains without crashing

## Context
- stacked on top of #219 so the bridge-preview fix can stay focused
- should be retargeted to `main` after #219 merges

## Verification
- `pnpm --filter @initia/interwovenkit-react test`
- `pnpm --filter @initia/interwovenkit-react typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chain-resolution and bridge exact-fee validation paths; mistakes could surface as missing links/withdrawal data or incorrect fee-check behavior, but changes are localized and covered by new unit tests.
> 
> **Overview**
> Adds a distinct *display-only* deleted-chain fallback (`ResolvedChain` + `isDeletedChain`) and splits lookups into `useFindChain` (active registry only) vs `useFindChainDisplay` (profiles-based fallback).
> 
> Updates consumers to handle unavailable chains gracefully: `ExplorerLink` now renders non-clickable text for deleted/missing chains (and strips anchor-only attrs), and OP withdrawals surfaces show an informational message instead of throwing.
> 
> Bridge exact-fee checking is refactored to a shared `shouldCheckExactFee` helper and now uses `useChainEnabled`/`resolveEnabledChainState` to only fetch chain registry data when needed, with added tests for both the gating logic and enabled-query state handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a4217cd437417b3c6462c9a9be4b552c7795caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now uses a display-aware chain lookup so removed networks render a clear display-only fallback (logo/name) instead of failing.
  * Components gracefully handle conditional loading of chain info to avoid unexpected errors during fetches.

* **Bug Fixes**
  * Claimable and Withdrawals views show an informative message when a chain is removed.
  * Explorer links render as non-clickable text for unavailable chains and omit link-only attributes to avoid broken or misleading links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->