### PR TITLE
fix(vip): fallback to profiles for deleted chains

### DIFF
--- a/packages/interwovenkit-react/src/components/Image.tsx
+++ b/packages/interwovenkit-react/src/components/Image.tsx
@@ -34,7 +34,9 @@ const Image = ({ src, alt, placeholder, classNames, style, logo, ...attrs }: Pro
       className={clsx(attrs.className, { [styles.logo]: logo })}
       style={{ width, height, ...style }}
       src={src}
-      alt={alt}
+      // Default to alt="" (decorative) so screen readers skip the image
+      // instead of announcing the src filename.
+      alt={alt ?? ""}
       loading="lazy"
       onError={() => setErrorSrc(src)}
     />

--- a/packages/interwovenkit-react/src/data/initia-vip.ts
+++ b/packages/interwovenkit-react/src/data/initia-vip.ts
@@ -54,7 +54,8 @@ export interface VipPositionRow {
   bridgeId: number
   version: number
   name: string
-  logoUrl?: string
+  /** Always truthy: falls back to placeholder when the chain has no logo */
+  logoUrl: string
   lockedReward: number
   lockedRewardValue: number
   claimableReward: number

--- a/packages/interwovenkit-react/src/data/initia-vip.ts
+++ b/packages/interwovenkit-react/src/data/initia-vip.ts
@@ -192,8 +192,8 @@ export function useInitiaVipPositions(): VipSectionData {
           bridgeId: entry.rollup.bridgeId,
           version: entry.rollup.version,
           // Chains removed from chains.json may still have VIP rewards
-          name: chain?.name ?? `Bridge #${entry.rollup.bridgeId}`,
-          logoUrl: chain?.logoUrl ?? placeholder,
+          name: chain?.name || `Bridge #${entry.rollup.bridgeId}`,
+          logoUrl: chain?.logoUrl || placeholder,
           lockedReward: lockedFormatted,
           lockedRewardValue,
           claimableReward: claimableFormatted,

--- a/packages/interwovenkit-react/src/data/initia-vip.ts
+++ b/packages/interwovenkit-react/src/data/initia-vip.ts
@@ -5,10 +5,11 @@ import { useQuery } from "@tanstack/react-query"
 import { createQueryKeys } from "@lukemorales/query-key-factory"
 import { fromBaseUnit } from "@initia/utils"
 import { useInitiaAddress } from "@/public/data/hooks"
-import { useInitiaRegistry, useLayer1, usePricesQuery } from "./chains"
+import { useInitiaRegistry, useLayer1, usePricesQuery, useProfilesRegistry } from "./chains"
 import { useConfig } from "./config"
 import { INIT_DECIMALS, INIT_DENOM } from "./constants"
 import { STALE_TIMES } from "./http"
+import placeholder from "./placeholder"
 
 // ============================================
 // QUERY KEYS
@@ -125,15 +126,22 @@ export function useAllVipVestingPositions() {
   })
 }
 
-/** Hook to find chain profile by bridgeId */
+/** Hook to find chain display info (name, logo) by bridgeId */
 export function useFindChainByBridgeId() {
   const chains = useInitiaRegistry()
+  const profiles = useProfilesRegistry()
 
   return useCallback(
     (bridgeId: number | string) => {
-      return chains.find(({ metadata }) => metadata?.op_bridge_id === String(bridgeId))
+      const chain = chains.find(({ metadata }) => metadata?.op_bridge_id === String(bridgeId))
+      if (chain) return chain
+
+      // Fallback to profiles.json for chains removed from chains.json (same pattern as useFindChain)
+      const profile = profiles.find((profile) => profile.op_bridge_id === String(bridgeId))
+      if (!profile) return undefined
+      return { name: profile.pretty_name, logoUrl: profile.logo }
     },
-    [chains],
+    [chains, profiles],
   )
 }
 
@@ -183,8 +191,9 @@ export function useInitiaVipPositions(): VipSectionData {
         return {
           bridgeId: entry.rollup.bridgeId,
           version: entry.rollup.version,
-          name: chain?.name ?? "",
-          logoUrl: chain?.logoUrl,
+          // Chains removed from chains.json may still have VIP rewards
+          name: chain?.name ?? `Bridge #${entry.rollup.bridgeId}`,
+          logoUrl: chain?.logoUrl ?? placeholder,
           lockedReward: lockedFormatted,
           lockedRewardValue,
           claimableReward: claimableFormatted,

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/VipSection.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/VipSection.tsx
@@ -67,9 +67,7 @@ const VipRow = ({ row }: VipRowProps) => {
               aria-hidden="true"
             />
             <div className={styles.tokenInfoLabel}>
-              {logoUrl && (
-                <Image src={logoUrl} width={20} height={20} className={styles.tokenLogo} logo />
-              )}
+              <Image src={logoUrl} width={20} height={20} className={styles.tokenLogo} logo />
               <span className={styles.tokenName}>{name}</span>
             </div>
           </div>


### PR DESCRIPTION
- VIP rows showed no name/logo when bridge_id is missing from chains.json
- look up profiles.json by op_bridge_id (same pattern as useFindChain)
- render "Bridge #N" and placeholder icon when no profile exists either

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only VIP/registry lookup and image alt defaults; no auth, payments, or API contract changes.
> 
> **Overview**
> Fixes **VIP portfolio rows** when a vesting position’s `bridge_id` no longer appears in `chains.json`: chain display now resolves through **`profiles.json` by `op_bridge_id`** (same idea as `useFindChain`), uses **`Bridge #<id>`** and a **placeholder logo** when nothing matches, and **`logoUrl` is always set** on each row.
> 
> **`VipSection`** always renders the row logo via **`Image`** (no conditional on `logoUrl`). **`Image`** defaults **`alt` to `""`** when omitted so decorative logos are not read as filenames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30059eaa7cff10b683cc6cf859cebc598b337c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VIP vesting display with better chain lookup fallbacks using profile data when chain info is missing.
  * Added readable bridge fallback names (e.g., "Bridge #<id>") and a placeholder logo when chain or logo data is absent.

* **Refactor**
  * Token rows now always render a logo image, falling back to the placeholder when needed.

* **Accessibility**
  * Images default to an empty alt text when none is provided so decorative images are ignored by screen readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->