### PR TITLE
fix(send): pin iUSD after INIT in Send asset picker

### DIFF
--- a/packages/interwovenkit-react/src/data/account.test.ts
+++ b/packages/interwovenkit-react/src/data/account.test.ts
@@ -45,15 +45,51 @@ describe("sortSendBalanceItems", () => {
     expect(sorted.map(({ symbol }) => symbol)).toEqual(["INIT", "iUSD", "USDC", "ETH"])
   })
 
-  it("should sort alphabetically by symbol when higher-priority fields tie", () => {
+  it("should prioritize listed assets when higher-priority fields tie", () => {
     const items = [
-      createItem({ symbol: "USDC", denom: "uusdc" }),
-      createItem({ symbol: "ETH", denom: "ueth" }),
-      createItem({ symbol: "ATOM", denom: "uatom" }),
+      createItem({ symbol: "UNLISTED", denom: "uunlisted", value: 10 }),
+      createItem({ symbol: "LISTED", denom: "ulisted", value: 10 }),
+    ]
+
+    const sorted = sortSendBalanceItems(items, {
+      isFeeToken: () => false,
+      isListed: (denom) => denom === "ulisted",
+    })
+
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["LISTED", "UNLISTED"])
+  })
+
+  it("should sort by balance when higher-priority fields tie", () => {
+    const items = [
+      createItem({ symbol: "SMALL", denom: "usmall", balance: "1000", value: 10 }),
+      createItem({ symbol: "LARGE", denom: "ularge", balance: "2000", value: 10 }),
     ]
 
     const sorted = sortSendBalanceItems(items, sorters)
 
-    expect(sorted.map(({ symbol }) => symbol)).toEqual(["ATOM", "ETH", "USDC"])
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["LARGE", "SMALL"])
+  })
+
+  it("should treat empty balances as zero", () => {
+    const items = [
+      createItem({ symbol: "EMPTY", denom: "uempty", balance: "", value: 10 }),
+      createItem({ symbol: "FUNDED", denom: "ufunded", balance: "1", value: 10 }),
+    ]
+
+    const sorted = sortSendBalanceItems(items, sorters)
+
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["FUNDED", "EMPTY"])
+  })
+
+  it("should sort alphabetically by symbol when higher-priority fields tie", () => {
+    const items = [
+      createItem({ symbol: "ctoken" }),
+      createItem({ symbol: "Btoken" }),
+      createItem({ symbol: "aToken" }),
+    ]
+
+    const sorted = sortSendBalanceItems(items, sorters)
+
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["aToken", "Btoken", "ctoken"])
   })
 })

--- a/packages/interwovenkit-react/src/data/account.test.ts
+++ b/packages/interwovenkit-react/src/data/account.test.ts
@@ -47,8 +47,8 @@ describe("sortSendBalanceItems", () => {
 
   it("should prioritize listed assets when higher-priority fields tie", () => {
     const items = [
-      createItem({ symbol: "UNLISTED", denom: "uunlisted", value: 10 }),
-      createItem({ symbol: "LISTED", denom: "ulisted", value: 10 }),
+      createItem({ symbol: "ALPHA", denom: "uunlisted", value: 10 }),
+      createItem({ symbol: "ZETA", denom: "ulisted", value: 10 }),
     ]
 
     const sorted = sortSendBalanceItems(items, {
@@ -56,18 +56,18 @@ describe("sortSendBalanceItems", () => {
       isListed: (denom) => denom === "ulisted",
     })
 
-    expect(sorted.map(({ symbol }) => symbol)).toEqual(["LISTED", "UNLISTED"])
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["ZETA", "ALPHA"])
   })
 
   it("should sort by balance when higher-priority fields tie", () => {
     const items = [
-      createItem({ symbol: "SMALL", denom: "usmall", balance: "1000", value: 10 }),
-      createItem({ symbol: "LARGE", denom: "ularge", balance: "2000", value: 10 }),
+      createItem({ symbol: "ALPHA", denom: "ualpha", balance: "1000", value: 10 }),
+      createItem({ symbol: "ZETA", denom: "uzeta", balance: "2000", value: 10 }),
     ]
 
     const sorted = sortSendBalanceItems(items, sorters)
 
-    expect(sorted.map(({ symbol }) => symbol)).toEqual(["LARGE", "SMALL"])
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["ZETA", "ALPHA"])
   })
 
   it("should treat empty balances as zero", () => {

--- a/packages/interwovenkit-react/src/data/account.test.ts
+++ b/packages/interwovenkit-react/src/data/account.test.ts
@@ -42,4 +42,16 @@ describe("sortSendBalanceItems", () => {
 
     expect(sorted.map(({ symbol }) => symbol)).toEqual(["INIT", "iUSD", "USDC"])
   })
+
+  it("should sort alphabetically by symbol when higher-priority fields tie", () => {
+    const items = [
+      createItem({ symbol: "USDC", denom: "uusdc" }),
+      createItem({ symbol: "ETH", denom: "ueth" }),
+      createItem({ symbol: "ATOM", denom: "uatom" }),
+    ]
+
+    const sorted = sortSendBalanceItems(items, sorters)
+
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["ATOM", "ETH", "USDC"])
+  })
 })

--- a/packages/interwovenkit-react/src/data/account.test.ts
+++ b/packages/interwovenkit-react/src/data/account.test.ts
@@ -59,6 +59,20 @@ describe("sortSendBalanceItems", () => {
     expect(sorted.map(({ symbol }) => symbol)).toEqual(["ZETA", "ALPHA"])
   })
 
+  it("should sort by value before listed status", () => {
+    const items = [
+      createItem({ symbol: "LOW", denom: "ulisted", value: 1 }),
+      createItem({ symbol: "HIGH", denom: "uunlisted", value: 100 }),
+    ]
+
+    const sorted = sortSendBalanceItems(items, {
+      isFeeToken: () => false,
+      isListed: (denom) => denom === "ulisted",
+    })
+
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["HIGH", "LOW"])
+  })
+
   it("should sort by balance when higher-priority fields tie", () => {
     const items = [
       createItem({ symbol: "ALPHA", denom: "ualpha", balance: "1000", value: 10 }),

--- a/packages/interwovenkit-react/src/data/account.test.ts
+++ b/packages/interwovenkit-react/src/data/account.test.ts
@@ -1,0 +1,45 @@
+import { type SendBalanceSortItem, sortSendBalanceItems } from "./account"
+
+function createItem(overrides: Partial<SendBalanceSortItem> & Pick<SendBalanceSortItem, "symbol">) {
+  return {
+    denom: overrides.symbol.toLowerCase(),
+    balance: "1000000",
+    value: 10,
+    ...overrides,
+  }
+}
+
+describe("sortSendBalanceItems", () => {
+  const sorters = {
+    isFeeToken: () => false,
+    isListed: () => true,
+  }
+
+  it("should keep iUSD right after INIT regardless of value", () => {
+    const items = [
+      createItem({ symbol: "USDC", denom: "uusdc", value: 100 }),
+      createItem({ symbol: "iUSD", denom: "iusd", value: 5 }),
+      createItem({ symbol: "INIT", denom: "uinit", value: 1 }),
+      createItem({ symbol: "ETH", denom: "ueth", value: 50 }),
+    ]
+
+    const sorted = sortSendBalanceItems(items, sorters)
+
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["INIT", "iUSD", "USDC", "ETH"])
+  })
+
+  it("should still prioritize fee tokens after pinned assets", () => {
+    const items = [
+      createItem({ symbol: "USDC", denom: "uusdc", value: 1 }),
+      createItem({ symbol: "INIT", denom: "uinit", value: 100 }),
+      createItem({ symbol: "iUSD", denom: "iusd", value: 50 }),
+    ]
+
+    const sorted = sortSendBalanceItems(items, {
+      isFeeToken: (denom) => denom === "uusdc",
+      isListed: () => true,
+    })
+
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["INIT", "iUSD", "USDC"])
+  })
+})

--- a/packages/interwovenkit-react/src/data/account.test.ts
+++ b/packages/interwovenkit-react/src/data/account.test.ts
@@ -30,8 +30,9 @@ describe("sortSendBalanceItems", () => {
 
   it("should still prioritize fee tokens after pinned assets", () => {
     const items = [
+      createItem({ symbol: "ETH", denom: "ueth", value: 100 }),
       createItem({ symbol: "USDC", denom: "uusdc", value: 1 }),
-      createItem({ symbol: "INIT", denom: "uinit", value: 100 }),
+      createItem({ symbol: "INIT", denom: "uinit", value: 50 }),
       createItem({ symbol: "iUSD", denom: "iusd", value: 50 }),
     ]
 
@@ -40,7 +41,8 @@ describe("sortSendBalanceItems", () => {
       isListed: () => true,
     })
 
-    expect(sorted.map(({ symbol }) => symbol)).toEqual(["INIT", "iUSD", "USDC"])
+    // USDC (fee token, value 1) must beat ETH (non-fee, value 100) despite the lower value
+    expect(sorted.map(({ symbol }) => symbol)).toEqual(["INIT", "iUSD", "USDC", "ETH"])
   })
 
   it("should sort alphabetically by symbol when higher-priority fields tie", () => {

--- a/packages/interwovenkit-react/src/data/account.ts
+++ b/packages/interwovenkit-react/src/data/account.ts
@@ -35,9 +35,9 @@ export function sortSendBalanceItems<T extends SendBalanceSortItem>(
       descend(({ denom }) => isFeeToken(denom)),
       descend(({ value }) => value),
       descend(({ denom }) => isListed(denom)),
-      // `|| 0` keeps BigNumber strict-mode from throwing on empty balances. `?? 0` guards
-      // comparedTo's null-on-NaN return; unreachable only because balance is always a numeric
-      // cosmos Coin.amount, but kept since this exported helper doesn't enforce that contract.
+      // `|| 0` maps empty Coin.amount strings to 0 (BigNumber throws on "" under strict mode).
+      // `?? 0` covers comparedTo's null-on-NaN return, reachable only for a non-empty,
+      // non-numeric balance, which Coin.amount never is, but kept for this exported helper.
       ({ balance: a }, { balance: b }) => BigNumber(b || 0).comparedTo(a || 0) ?? 0,
       ascend(({ symbol }) => symbol.toLowerCase()),
     ],

--- a/packages/interwovenkit-react/src/data/account.ts
+++ b/packages/interwovenkit-react/src/data/account.ts
@@ -1,15 +1,48 @@
 import BigNumber from "bignumber.js"
 import type { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin"
-import { descend, sortWith } from "ramda"
+import { ascend, descend, sortWith } from "ramda"
 import { queryOptions, useQueries, useSuspenseQuery } from "@tanstack/react-query"
 import { createQueryKeys } from "@lukemorales/query-key-factory"
 import { useInitiaAddress } from "@/public/data/hooks"
-import { useAssets, useFindAsset, useGetLayer1Denom } from "./assets"
+import { useAssets, useFindAsset } from "./assets"
 import { type NormalizedChain, useInitiaRegistry, useLayer1, usePricesQuery } from "./chains"
 import { useConfig } from "./config"
 import { STALE_TIMES } from "./http"
 import { fetchAllPages } from "./pagination"
+import { getPinnedAssetSymbolRank } from "./pinnedAssets"
 import { createUsernameClient } from "./username"
+
+export interface SendBalanceSortItem {
+  symbol: string
+  denom: string
+  balance: string
+  value: number
+}
+
+export function sortSendBalanceItems<T extends SendBalanceSortItem>(
+  items: T[],
+  {
+    isFeeToken,
+    isListed,
+  }: {
+    isFeeToken: (denom: string) => boolean
+    isListed: (denom: string) => boolean
+  },
+): T[] {
+  return sortWith(
+    [
+      ascend(({ symbol }) => getPinnedAssetSymbolRank(symbol)),
+      descend(({ denom }) => isFeeToken(denom)),
+      descend(({ value }) => value),
+      descend(({ denom }) => isListed(denom)),
+      // `|| 0` keeps BigNumber strict-mode from throwing on empty balances; `?? 0` is leftover
+      // defense for comparedTo's null-on-NaN return, which the upstream guards now make unreachable.
+      ({ balance: a }, { balance: b }) => BigNumber(b || 0).comparedTo(a || 0) ?? 0,
+      descend(({ symbol }) => symbol.toLowerCase()),
+    ],
+    items,
+  )
+}
 
 export const accountQueryKeys = createQueryKeys("interwovenkit:account", {
   username: (restUrl: string, address: string) => [restUrl, address],
@@ -60,7 +93,6 @@ export function useSortedBalancesWithValue(chain: NormalizedChain) {
   const balances = useBalances(chain)
   const assets = useAssets(chain)
   const findAsset = useFindAsset(chain)
-  const getLayer1Denom = useGetLayer1Denom(chain)
 
   const { data: prices } = usePricesQuery(chain)
 
@@ -72,17 +104,7 @@ export function useSortedBalancesWithValue(chain: NormalizedChain) {
     return assets.some((asset) => asset.denom === denom)
   }
 
-  return sortWith(
-    [
-      descend(({ denom }) => getLayer1Denom(denom) === "uinit"),
-      descend(({ denom }) => isFeeToken(denom)),
-      descend(({ value }) => value),
-      descend(({ denom }) => isListed(denom)),
-      // `|| 0` keeps BigNumber strict-mode from throwing on empty balances; `?? 0` is leftover
-      // defense for comparedTo's null-on-NaN return, which the upstream guards now make unreachable.
-      ({ balance: a }, { balance: b }) => BigNumber(b || 0).comparedTo(a || 0) ?? 0,
-      descend(({ symbol }) => symbol.toLowerCase()),
-    ],
+  return sortSendBalanceItems(
     balances
       .filter(({ amount }) => !BigNumber(amount || 0).isZero())
       .map(({ amount: balance, denom }) => {
@@ -94,5 +116,6 @@ export function useSortedBalancesWithValue(chain: NormalizedChain) {
           .toNumber()
         return { ...asset, balance, price, value }
       }),
+    { isFeeToken, isListed },
   )
 }

--- a/packages/interwovenkit-react/src/data/account.ts
+++ b/packages/interwovenkit-react/src/data/account.ts
@@ -35,9 +35,8 @@ export function sortSendBalanceItems<T extends SendBalanceSortItem>(
       descend(({ denom }) => isFeeToken(denom)),
       descend(({ value }) => value),
       descend(({ denom }) => isListed(denom)),
-      // `|| 0` maps empty Coin.amount strings to 0 (BigNumber throws on "" under strict mode).
-      // `?? 0` covers comparedTo's null-on-NaN return, reachable only for a non-empty,
-      // non-numeric balance, which Coin.amount never is, but kept for this exported helper.
+      // `|| 0` maps empty Coin.amount strings to 0 before BigNumber parses them.
+      // `?? 0` keeps comparedTo's null-on-NaN return out of the sort comparator.
       ({ balance: a }, { balance: b }) => BigNumber(b || 0).comparedTo(a || 0) ?? 0,
       ascend(({ symbol }) => symbol.toLowerCase()),
     ],

--- a/packages/interwovenkit-react/src/data/account.ts
+++ b/packages/interwovenkit-react/src/data/account.ts
@@ -35,8 +35,9 @@ export function sortSendBalanceItems<T extends SendBalanceSortItem>(
       descend(({ denom }) => isFeeToken(denom)),
       descend(({ value }) => value),
       descend(({ denom }) => isListed(denom)),
-      // `|| 0` maps empty Coin.amount strings to 0 before BigNumber parses them.
-      // `?? 0` keeps comparedTo's null-on-NaN return out of the sort comparator.
+      // Both fallbacks are intentional and type-required, not dead code, despite looking redundant.
+      // `?? 0`: comparedTo is declared `1 | -1 | 0 | null`, and a ramda comparator must return `number`.
+      // `|| 0`: an empty balance string must not reach BigNumber as "" (NaN; throws under strict mode).
       ({ balance: a }, { balance: b }) => BigNumber(b || 0).comparedTo(a || 0) ?? 0,
       ascend(({ symbol }) => symbol.toLowerCase()),
     ],

--- a/packages/interwovenkit-react/src/data/account.ts
+++ b/packages/interwovenkit-react/src/data/account.ts
@@ -38,7 +38,7 @@ export function sortSendBalanceItems<T extends SendBalanceSortItem>(
       // `|| 0` keeps BigNumber strict-mode from throwing on empty balances; `?? 0` is leftover
       // defense for comparedTo's null-on-NaN return, which the upstream guards now make unreachable.
       ({ balance: a }, { balance: b }) => BigNumber(b || 0).comparedTo(a || 0) ?? 0,
-      descend(({ symbol }) => symbol.toLowerCase()),
+      ascend(({ symbol }) => symbol.toLowerCase()),
     ],
     items,
   )

--- a/packages/interwovenkit-react/src/data/account.ts
+++ b/packages/interwovenkit-react/src/data/account.ts
@@ -35,8 +35,9 @@ export function sortSendBalanceItems<T extends SendBalanceSortItem>(
       descend(({ denom }) => isFeeToken(denom)),
       descend(({ value }) => value),
       descend(({ denom }) => isListed(denom)),
-      // `|| 0` keeps BigNumber strict-mode from throwing on empty balances; `?? 0` is leftover
-      // defense for comparedTo's null-on-NaN return, which the upstream guards now make unreachable.
+      // `|| 0` keeps BigNumber strict-mode from throwing on empty balances. `?? 0` guards
+      // comparedTo's null-on-NaN return; unreachable only because balance is always a numeric
+      // cosmos Coin.amount, but kept since this exported helper doesn't enforce that contract.
       ({ balance: a }, { balance: b }) => BigNumber(b || 0).comparedTo(a || 0) ?? 0,
       ascend(({ symbol }) => symbol.toLowerCase()),
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #237 — the Send asset picker was still using the old INIT-only denom pin and did not place iUSD after INIT.

This change extracts `sortSendBalanceItems` from `useSortedBalancesWithValue` and applies the shared `getPinnedAssetSymbolRank` helper so Send matches Bridge, Portfolio, and Minity ordering.

## Sort order (Send picker)

1. Pinned rank (`INIT` → `iUSD`)
2. Fee token
3. USD value ↓
4. Listed in registry
5. Raw balance ↓
6. Symbol A→Z

## Test plan

- [x] `pnpm test src/data/account.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efc730d8-20b6-4962-bae8-63648ed2a269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efc730d8-20b6-4962-bae8-63648ed2a269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send-flow balance sorting so the `INIT` asset stays pinned immediately before `iUSD`, while maintaining correct fee-token prioritization.
  * Ensures consistent, deterministic ordering for the remaining assets (including correct handling when balances are empty/treated as zero).
* **Tests**
  * Added unit tests covering pinned-asset behavior, fee-token handling, and stable alphabetical ordering when sort priorities tie.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->