### PR TITLE
fix(deposit): skip asset picker for single option

### DIFF
--- a/examples/vite/src/Deposit.tsx
+++ b/examples/vite/src/Deposit.tsx
@@ -1,28 +1,41 @@
 import { useInterwovenKit } from "@initia/interwovenkit-react"
 import styles from "./Button.module.css"
 
+const INIT_DENOM = "uinit"
+const USDC_DENOM = "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4"
+const ETH_DENOM = "move/edfcddacac79ab86737a1e9e65805066d8be286a37cb94f4884b892b0e39f954"
+const IUSD_DENOM = "move/6c69733a9e722f3660afb524f89fce957801fa7e4408b8ef8fe89db9627b570e"
+
+const DENOMS = [INIT_DENOM, USDC_DENOM, ETH_DENOM, IUSD_DENOM]
+
+const CHAIN_ID = "interwoven-1"
+
 const Deposit = () => {
   const { address, openDeposit } = useInterwovenKit()
 
   if (!address) return null
 
   return (
-    <button
-      className={styles.button}
-      onClick={() =>
-        openDeposit({
-          denoms: [
-            "uinit",
-            "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4",
-            "move/edfcddacac79ab86737a1e9e65805066d8be286a37cb94f4884b892b0e39f954",
-            "move/6c69733a9e722f3660afb524f89fce957801fa7e4408b8ef8fe89db9627b570e",
-          ],
-          chainId: "interwoven-1",
-        })
-      }
-    >
-      Deposit
-    </button>
+    <>
+      <button
+        className={styles.button}
+        onClick={() => openDeposit({ denoms: DENOMS, chainId: CHAIN_ID })}
+      >
+        Deposit
+      </button>
+      <button
+        className={styles.button}
+        onClick={() => openDeposit({ denoms: [INIT_DENOM], chainId: CHAIN_ID })}
+      >
+        Deposit INIT
+      </button>
+      <button
+        className={styles.button}
+        onClick={() => openDeposit({ denoms: [IUSD_DENOM], chainId: CHAIN_ID })}
+      >
+        Deposit iUSD
+      </button>
+    </>
   )
 }
 

--- a/packages/interwovenkit-react/src/pages/deposit/SelectLocalAsset.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/SelectLocalAsset.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useTransition } from "react"
+import { useTransition } from "react"
 import { type TransferMode, useLocalAssetOptions, useTransferForm, useTransferMode } from "./hooks"
 import styles from "./SelectLocalAsset.module.css"
 
@@ -9,7 +9,7 @@ interface Props {
 const SelectLocalAsset = ({ mode }: Props) => {
   const { local, external } = useTransferMode(mode)
   const { setValue } = useTransferForm()
-  const { data: options, isLoading } = useLocalAssetOptions()
+  const { data: options } = useLocalAssetOptions()
   const [isPending, startTransition] = useTransition()
 
   const selectLocalAsset = (denom: string, chain_id: string) => {
@@ -26,17 +26,6 @@ const SelectLocalAsset = ({ mode }: Props) => {
       setValue("page", mode === "withdraw" ? "fields" : "select-external")
     })
   }
-
-  const selectDefaultAsset = useEffectEvent(() => {
-    const { denom, chain_id } = options[0]
-    selectLocalAsset(denom, chain_id)
-  })
-
-  useEffect(() => {
-    if (!isLoading && options.length === 1) {
-      selectDefaultAsset()
-    }
-  }, [options, isLoading])
 
   if (!options.length) {
     return <div>No assets found</div>

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFields.tsx
@@ -288,8 +288,8 @@ const TransferFields = ({ mode }: Props) => {
 
     // When hasSingleExternalAssetOption, navigating to select-external would
     // immediately auto-fill and jump back to fields, creating an infinite loop.
-    // Go directly to select-local instead, which is safe because the Back button
-    // only renders when options.length > 1 (so select-local won't auto-skip).
+    // Go directly to select-local instead; select-local never navigates away on
+    // its own, so this cannot loop.
     const previousPage =
       mode === "withdraw" || hasSingleExternalAssetOption ? "select-local" : "select-external"
     setValue("page", previousPage)

--- a/packages/interwovenkit-react/src/pages/deposit/TransferFlow.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/TransferFlow.tsx
@@ -1,11 +1,14 @@
 import { animated, useTransition } from "@react-spring/web"
 import { FormProvider, useForm } from "react-hook-form"
 import AnimatedHeight from "@/components/AnimatedHeight"
+import { useLocationState } from "@/lib/router"
 import {
+  type AssetOption,
   type TransferFormValues,
   type TransferMode,
   useAllBalancesQuery,
   useTransferForm,
+  useTransferMode,
 } from "./hooks"
 import SelectExternalAsset from "./SelectExternalAsset"
 import SelectLocalAsset from "./SelectLocalAsset"
@@ -18,17 +21,28 @@ interface Props {
 }
 
 const TransferFlow = ({ mode }: Props) => {
-  const form = useForm<TransferFormValues>({
-    mode: "onChange",
-    defaultValues: {
-      page: "select-local",
-      quantity: "",
-      srcDenom: "",
-      srcChainId: "",
-      dstDenom: "",
-      dstChainId: "",
-    },
-  })
+  const { local } = useTransferMode(mode)
+  const { localOptions = [] } = useLocationState<{ localOptions?: AssetOption[] }>()
+
+  const defaultValues: TransferFormValues = {
+    page: "select-local",
+    quantity: "",
+    srcDenom: "",
+    srcChainId: "",
+    dstDenom: "",
+    dstChainId: "",
+  }
+
+  // With a single local asset there is nothing to pick, so pre-select it and
+  // skip the "select-local" page entirely to avoid flashing the asset picker.
+  if (localOptions.length === 1) {
+    const [{ denom, chainId }] = localOptions
+    defaultValues[local.denomKey] = denom
+    defaultValues[local.chainIdKey] = chainId
+    defaultValues.page = mode === "deposit" ? "select-external" : "fields"
+  }
+
+  const form = useForm<TransferFormValues>({ mode: "onChange", defaultValues })
 
   // prefetch balances
   useAllBalancesQuery()


### PR DESCRIPTION
## Problem

When a host dApp calls `openDeposit({ denoms: [single denom] })`, the flow should land directly on the "Deposit {symbol}" screen, but it passes through the "Select an asset to receive" screen even though there is only one asset to choose. The flash is usually too brief to notice, but depending on network conditions (cold Skip query cache) it can become clearly visible. `openWithdraw` shares the same structure and has the same issue.

## Cause

- The form's initial page in `TransferFlow` is hardcoded to `"select-local"` regardless of how many `localOptions` are in the location state, so the picker mounts first.
- Skipping is performed after render by a `useEffect` in `SelectLocalAsset`, which keeps the picker visible while waiting for the Skip `v2/fungible/assets` query (`!isLoading` gate) and the next page's suspense to resolve (`startTransition`).
- The only values needed to decide the skip are `denom`/`chainId`, which are available from the location state before rendering.

## Changes

- `TransferFlow`: when `localOptions` has exactly one entry, prefill the local asset into `defaultValues` and set the initial page to `select-external` for deposit and `fields` for withdraw. The picker never mounts, so the flash is eliminated structurally.
- `SelectLocalAsset`: remove the auto-skip `useEffect`, which is now unreachable. The multi-option selection flow is unchanged.
- `examples/vite`: add "Deposit INIT" and "Deposit iUSD" buttons for verifying single-denom entry.

The first screen on single-option entry is now a suspense component, but the required Skip queries are prefetched when `InterwovenKitProvider` mounts, so the "Loading…" fallback only appears briefly in the narrow case of opening the flow right after the widget mounts.

## Verification

- `pnpm test`, `pnpm typecheck`, `pnpm lint` pass
- Verified in the demo with Playwright, using a MutationObserver on the shadow root to watch for any appearance of the "Select an asset" text
  - Single-denom deposit/withdraw: the picker never appears, not even for a single frame (zero observations), and the flow lands directly on the target screen
  - Multi-denom deposit/withdraw: the existing picker flow is preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deposit/withdraw UX and initial routing only; multi-asset flows and selection logic stay the same.
> 
> **Overview**
> Fixes a visible flash of **“Select an asset to receive”** when host apps open deposit/withdraw with only one `denom` in `openDeposit` / `openWithdraw`.
> 
> **`TransferFlow`** now reads `localOptions` from location state and, when there is exactly one entry, pre-fills the local denom/chain into form `defaultValues` and starts on **`select-external`** (deposit) or **`fields`** (withdraw) so the local picker never mounts.
> 
> **`SelectLocalAsset`** drops the post-render `useEffect` auto-skip (and related loading handling); multi-asset selection is unchanged.
> 
> **`TransferFields`** only updates the back-navigation comment to match the new behavior (no auto-skip on select-local).
> 
> The Vite example adds **Deposit INIT** / **Deposit iUSD** buttons and shared denom constants to exercise single-denom entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0331bce784caeffca3dd3086baad4c290da179d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more deposit entry options, letting users start a deposit with all assets or restrict it to a specific asset.
  * Improved deposit flow by automatically pre-filling details when only one local asset is available.

* **Bug Fixes**
  * Removed an automatic asset-selection step that could cause unexpected navigation behavior.
  * Updated deposit navigation to better avoid looping during auto-fill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->