### PR TITLE
fix: stop portfolio recomputing on every search keystroke

### DIFF
--- a/packages/interwovenkit-react/src/data/assets.ts
+++ b/packages/interwovenkit-react/src/data/assets.ts
@@ -76,6 +76,10 @@ export function useAllChainsAssetsQueries() {
   const createAssetsQuery = useCreateAssetsQuery()
   return useQueries({
     queries: chains.map((chain) => createAssetsQuery(chain)),
+    // `combine` keeps this array reference-stable across renders — plain
+    // `useQueries` returns a brand-new array every render otherwise.
+    combine: (results) =>
+      results.map(({ data, isLoading, refetch }) => ({ data, isLoading, refetch })),
   })
 }
 

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -216,5 +216,9 @@ export function useAllChainPriceQueries() {
   const createPricesQuery = useCreatePricesQuery()
   return useQueries({
     queries: chains.map((chain) => createPricesQuery(chain)),
+    // `combine` keeps this array reference-stable across renders — plain
+    // `useQueries` returns a brand-new array every render otherwise.
+    combine: (results) =>
+      results.map(({ data, isLoading, refetch }) => ({ data, isLoading, refetch })),
   })
 }


### PR DESCRIPTION
useQueries returns a brand-new array on every render without `combine`, so the useMemo caches downstream (asset logos, price maps, and memo(Assets)) never hit — every keystroke in the portfolio search rebuilt multi-thousand-entry maps and reprocessed all balances.

Verified by A/B testing each `combine` independently with console.count instrumentation: with both fixes active, typing produced zero recomputation of either map; removing either one reproduced the bug immediately, with a single keystroke triggering 6 wasted recomputes. Confirmed no regressions via typecheck, lint, and the full test suite (576 tests passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when loading asset and chain price data.
  * Reduced unnecessary updates for screens and components consuming these queries.
  * Preserved access to loading status, refreshed data, and manual refetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->