### PR TITLE
chore(example): pin dev server port to 17303

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pnpm dev
 ```
 
 - The package source files will be injected into the portal element in the document body.
-- The demo site will be available at: [http://localhost:5173](http://localhost:5173)
+- The demo site will be available at: [http://localhost:17303](http://localhost:17303)
 
 ### Production Mode
 
@@ -57,7 +57,7 @@ pnpm watch  # Serve the demo using the built package and styles.
 ```
 
 - In production mode, the package and its styles will be injected into a Shadow DOM.
-- The demo site will be available at: [http://localhost:5173](http://localhost:5173)
+- The demo site will be available at: [http://localhost:17303](http://localhost:17303)
 
 ## Deployment Security Headers
 

--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -8,4 +8,8 @@ export default defineConfig({
   },
   plugins: [react()],
   envPrefix: "INITIA_",
+  server: {
+    port: 17303,
+    strictPort: true,
+  },
 })


### PR DESCRIPTION
## Summary

- pin the Vite example dev server to port 17303
- fail when the configured port is unavailable instead of selecting another port

## Testing

- Not run (configuration-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and local dev server configuration only; no runtime or production deployment behavior changes.
> 
> **Overview**
> The Vite example dev server is **fixed to port `17303`** with **`strictPort: true`**, so startup fails if that port is already in use instead of silently picking another port.
> 
> **README** local dev and production-mode instructions now point to `http://localhost:17303` instead of `5173`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fab75921e3185685d8bbc69c28b50d5f462896c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured the development server to use port `17303`.
  * Enabled strict port handling so the app fails to start if `17303` is unavailable.

* **Documentation**
  * Updated “Running Locally” and “Production Mode” instructions in the README to use `http://localhost:17303` instead of the previous dev-server URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->