### PR TITLE
fix: harden external link and window.open openings

### DIFF
--- a/packages/interwovenkit-react/src/pages/bridge/BridgeAccount.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeAccount.tsx
@@ -45,7 +45,7 @@ const BridgeAccount = ({ type }: Props) => {
               const provider = item.getProvider()
               if (!provider) {
                 if (item.fallbackUrl) {
-                  window.open(item.fallbackUrl, "_blank")
+                  window.open(item.fallbackUrl, "_blank", "noopener,noreferrer")
                 } else {
                   showNotification({
                     type: "error",

--- a/packages/interwovenkit-react/src/pages/settings/ExportPrivateKey.tsx
+++ b/packages/interwovenkit-react/src/pages/settings/ExportPrivateKey.tsx
@@ -4,7 +4,7 @@ import SettingItem from "./SettingItem"
 const PRIVY_EXPORT_URL = "https://export.initia.xyz/"
 
 const ExportPrivateKey = () => {
-  const windowFeatures = "width=600,height=768,scrollbars=yes,resizable=yes"
+  const windowFeatures = "width=600,height=768,scrollbars=yes,resizable=yes,noopener,noreferrer"
 
   return (
     <SettingItem

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/AppchainPositionGroup.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/AppchainPositionGroup.tsx
@@ -3,6 +3,7 @@ import { Collapsible } from "radix-ui"
 import { useMemo } from "react"
 import { atom, useAtom } from "jotai"
 import { IconChevronDown, IconExternalLink } from "@initia/icons-react"
+import { sanitizeLink } from "@/components/explorer"
 import Image from "@/components/Image"
 import { useAllChainsAssetsQueries } from "@/data/assets"
 import { useInitiaRegistry } from "@/data/chains"
@@ -118,7 +119,7 @@ const AppchainPositionGroup = ({ chainGroup }: Props) => {
               )}
               {manageUrl ? (
                 <a
-                  href={manageUrl}
+                  href={sanitizeLink(manageUrl)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className={styles.chainNameLink}

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/PositionSection.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/PositionSection.tsx
@@ -3,6 +3,7 @@ import { Collapsible } from "radix-ui"
 import { useMemo, useState } from "react"
 import { IconChevronDown, IconExternalLink } from "@initia/icons-react"
 import { formatNumber } from "@initia/utils"
+import { sanitizeLink } from "@/components/explorer"
 import Image from "@/components/Image"
 import { INIT_SYMBOL, STRAT_CHAIN_NAME } from "@/data/constants"
 import {
@@ -167,7 +168,7 @@ const PositionSection = ({
       <div className={styles.sectionHeader}>
         {showStakingBreakdown && manageUrl ? (
           <a
-            href={manageUrl}
+            href={sanitizeLink(manageUrl)}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.sectionTitleLink}


### PR DESCRIPTION
- Sanitized `manageUrl`: Passed portfolio position links from the minity API through `sanitizeLink` to block non-HTTP/HTTPS schemes.
- Prevented reverse tabnabbing: Added `noopener,noreferrer` to `window.open` calls for private key exports and wallet install fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Improved security when opening wallet fallback and private-key export pages by isolating new windows and suppressing referrer information.
  * Sanitized portfolio and staking management links before displaying them, helping prevent unsafe external URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->