### PR TITLE
feat(portfolio): price Strat xSLP vault positions via on-chain view call

### DIFF
--- a/examples/vite/src/Providers.tsx
+++ b/examples/vite/src/Providers.tsx
@@ -11,6 +11,7 @@ import {
 } from "@initia/interwovenkit-react"
 import css from "@initia/interwovenkit-react/styles.css?inline"
 import { chainId, depositApiUrl, isTestnet, routerApiUrl, useTheme } from "./data"
+import { mockStratPosition } from "./mockStratPosition"
 
 import type { PropsWithChildren } from "react"
 
@@ -27,6 +28,15 @@ const wagmiConfig = createConfig({
   transports: { [mainnet.id]: http() },
 })
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+// DEBUG ONLY — exposes queryClient as window.__qc, and window.__mockStratPosition(...) to inject
+// a fake Strat vault position into the portfolio cache. See mockStratPosition.ts for usage.
+if (import.meta.env.DEV) {
+  Object.assign(window, {
+    __qc: queryClient,
+    __mockStratPosition: (options?: Parameters<typeof mockStratPosition>[1]) =>
+      mockStratPosition(queryClient, options),
+  })
+}
 
 const InterwovenKitWrapper = ({ children }: PropsWithChildren) => {
   const theme = useTheme()

--- a/examples/vite/src/mockStratPosition.ts
+++ b/examples/vite/src/mockStratPosition.ts
@@ -1,0 +1,89 @@
+/* eslint-disable no-console -- this is a console-driven debug tool; console output is the point. */
+import type { QueryClient } from "@tanstack/react-query"
+
+interface MockStratPositionOptions {
+  /** Real xSLP denom on strat-1, confirmed via the Initia indexer asset list (symbol: "xSLP"). */
+  denom?: string
+  symbol?: string
+  amount?: number
+  protocol?: string
+}
+
+const REAL_XSLP_DENOM = "move/4e11c0a219f362e4d0e1f131699aa83bee40ebc8701b424373a8517d0c9e85fb"
+
+interface MinimalSSEPortfolioData {
+  balances: unknown[]
+  positions: { chainName: string }[]
+  isLoading: boolean
+  isComplete: boolean
+}
+
+/**
+ * DEBUG ONLY — injects a fake Strat vault position into the Minity SSE portfolio cache so the
+ * xSLP pricing pipeline (fallback pricing + Strat supplemental price) can be exercised without a
+ * real wallet holding a Strat position.
+ *
+ * Call from the browser console via `window.__mockStratPosition(...)`. Requires a wallet already
+ * connected with the Portfolio tab opened once, so the real `ssePortfolio` query key exists.
+ *
+ * Note: only validates the pricing math for the `denom` you pass in — it can't confirm whether
+ * Minity's real balance is xSLP or STRAT shares. Pass an unpriced `denom` (e.g. "ustrat") to see
+ * the safe unpriced fallback instead.
+ */
+export function mockStratPosition(
+  queryClient: QueryClient,
+  options: MockStratPositionOptions = {},
+) {
+  const { denom = REAL_XSLP_DENOM, symbol = "xSLP", amount = 5, protocol = "Strat Vault" } = options
+
+  const [query] = queryClient.getQueryCache().findAll({
+    queryKey: ["interwovenkit:minity", "ssePortfolio"],
+  })
+  if (!query) {
+    console.warn(
+      "[mockStratPosition] No ssePortfolio query found yet — connect a wallet and open the Portfolio tab first.",
+    )
+    return
+  }
+
+  const key = query.queryKey
+  const current = queryClient.getQueryData<MinimalSSEPortfolioData>(key) ?? {
+    balances: [],
+    positions: [],
+    isLoading: false,
+    isComplete: true,
+  }
+
+  const fakeStratChain = {
+    chainName: "strat",
+    chainId: "strat-1",
+    positions: [
+      {
+        protocol,
+        positions: [
+          {
+            type: "staking",
+            balance: {
+              type: "asset",
+              denom,
+              symbol,
+              decimals: 6,
+              amount: String(Math.round(amount * 1e6)),
+              formattedAmount: amount,
+              // no `value` — forces the fallback-pricing path (formattedAmount * price) to kick in
+            },
+          },
+        ],
+      },
+    ],
+  }
+
+  queryClient.setQueryData(key, {
+    ...current,
+    positions: [...current.positions.filter((data) => data.chainName !== "strat"), fakeStratChain],
+  })
+
+  console.log(
+    `[mockStratPosition] Injected ${amount} ${symbol} (denom: ${denom}) as a Strat vault position. Reopen the Portfolio tab to see it.`,
+  )
+}

--- a/packages/interwovenkit-react/src/components/AsyncBoundary.tsx
+++ b/packages/interwovenkit-react/src/components/AsyncBoundary.tsx
@@ -11,7 +11,11 @@ interface Props {
 }
 
 const AsyncBoundary = ({
-  errorBoundaryProps = { fallbackRender: ({ error }) => <Status error>{error.message}</Status> },
+  errorBoundaryProps = {
+    fallbackRender: ({ error }) => (
+      <Status error>{error instanceof Error ? error.message : String(error)}</Status>
+    ),
+  },
   suspenseFallback = <Status>Loading...</Status>,
   children,
 }: PropsWithChildren<Props>) => {

--- a/packages/interwovenkit-react/src/data/chains.ts
+++ b/packages/interwovenkit-react/src/data/chains.ts
@@ -3,13 +3,18 @@ import { descend, path } from "ramda"
 import { queryOptions, useQueries, useQuery, useSuspenseQuery } from "@tanstack/react-query"
 import { createQueryKeys } from "@lukemorales/query-key-factory"
 import type { Chain, ChainProfile, SecureEndpoint } from "@initia/initia-registry-types"
+import type { Config } from "./config"
 import { useConfig } from "./config"
 import { STALE_TIMES } from "./http"
+import { fetchStratSupplementalPrices } from "./strat"
 
 export const chainQueryKeys = createQueryKeys("interwovenkit:chain", {
   list: (registryUrl: string) => [registryUrl],
   profiles: (registryUrl: string) => [registryUrl],
-  prices: (chainId: string) => [chainId],
+  prices: (
+    chainId: string,
+    stratConfig: Pick<Config, "stratLpModuleAddress" | "stratXslpCollateralMetadata">,
+  ) => [chainId, stratConfig],
   gasPrices: (chain: NormalizedChain) => [chain],
 })
 
@@ -190,20 +195,44 @@ export function useLayer1() {
 export interface PriceItem {
   id: string
   price: number
+  /** Only present on the raw indexer response; used to look up well-known assets (e.g. "xSLP", "iUSD") by symbol rather than by a hardcoded denom. */
+  symbol?: string
 }
 
 function useCreatePricesQuery() {
-  return ({ chainId }: NormalizedChain) => {
+  const config = useConfig()
+  const { stratLpModuleAddress, stratXslpCollateralMetadata } = config
+  return (chain: NormalizedChain) => {
+    const { chainId } = chain
     return queryOptions({
-      queryKey: chainQueryKeys.prices(chainId).queryKey,
-      queryFn: () =>
-        ky
+      queryKey: chainQueryKeys.prices(chainId, {
+        stratLpModuleAddress,
+        stratXslpCollateralMetadata,
+      }).queryKey,
+      queryFn: async () => {
+        const prices = await ky
           .create({ prefixUrl: "https://indexer.initia.xyz" })
           .get(`initia/${chainId}/assets`, { searchParams: { quote: "USD", with_prices: true } })
-          .json<PriceItem[]>(),
+          .json<PriceItem[]>()
+        const supplementalPrices = await fetchStratSupplementalPrices(chain, prices, {
+          stratLpModuleAddress,
+          stratXslpCollateralMetadata,
+        })
+        return mergePriceItems(prices, supplementalPrices)
+      },
       staleTime: STALE_TIMES.SECOND,
     })
   }
+}
+
+function mergePriceItems(prices: PriceItem[], supplementalPrices: PriceItem[]) {
+  if (supplementalPrices.length === 0) return prices
+
+  const priceById = new Map(prices.map((price) => [price.id, price]))
+  for (const price of supplementalPrices) {
+    priceById.set(price.id, price)
+  }
+  return Array.from(priceById.values())
 }
 
 export function usePricesQuery(chain: NormalizedChain) {

--- a/packages/interwovenkit-react/src/data/config.ts
+++ b/packages/interwovenkit-react/src/data/config.ts
@@ -44,6 +44,10 @@ export interface Config {
   lockStakeModuleAddress: string
   /** Move module address for CLAMM vaults. */
   clammVaultModuleAddress: string
+  /** Strat `lp` module deployer address, used for xSLP pricing. Absent where Strat isn't deployed (e.g. testnet). */
+  stratLpModuleAddress?: string
+  /** Metadata of the xSLP vault's collateral asset (e.g. iUSD) — NOT xSLP's own metadata. See `fetchStratSupplementalPrices`. */
+  stratXslpCollateralMetadata?: string
   /** Minity portfolio API base URL (SSE streaming). */
   minityUrl: string
   /** DEX indexer API base URL for LP prices and positions. */

--- a/packages/interwovenkit-react/src/data/constants.ts
+++ b/packages/interwovenkit-react/src/data/constants.ts
@@ -13,6 +13,7 @@ export const OMNI_INIT_SYMBOL = "omniINIT"
 
 // Strat (perp DEX) chain identifier as it appears in Minity portfolio responses.
 export const STRAT_CHAIN_NAME = "strat"
+export const XSLP_SYMBOL = "xSLP"
 
 // External URLs
 export const INITIA_APP_URL = "https://app.initia.xyz"

--- a/packages/interwovenkit-react/src/data/minity/hooks.ts
+++ b/packages/interwovenkit-react/src/data/minity/hooks.ts
@@ -13,7 +13,12 @@ import type {
   ProtocolPosition,
   SSEPortfolioData,
 } from "./types"
-import { applyFallbackPricing, buildPriceMap, getPositionValue } from "./utilities"
+import {
+  applyFallbackPositionPricing,
+  applyFallbackPricing,
+  buildPriceMap,
+  getPositionValue,
+} from "./utilities"
 
 // ============================================
 // DEFAULT DATA
@@ -105,6 +110,8 @@ export function useChainInfoMap(): Map<string, ChainInfo> {
 export function useMinityChainBreakdown(): ChainBreakdownItem[] {
   const { balances, positions } = useMinityPortfolio()
   const registry = useInitiaRegistry()
+  const priceQueries = useAllChainPriceQueries()
+  const chainPrices = useMemo(() => buildPriceMap(registry, priceQueries), [registry, priceQueries])
 
   const registryMap = useMemo(() => {
     const map = new Map<string, (typeof registry)[number]>()
@@ -128,7 +135,9 @@ export function useMinityChainBreakdown(): ChainBreakdownItem[] {
     const chainTotals = new Map<string, number>()
 
     const safeBalances = Array.isArray(balances) ? balances : []
-    const safePositions = Array.isArray(positions) ? positions : []
+    const safePositions = Array.isArray(positions)
+      ? applyFallbackPositionPricing(positions, chainPrices)
+      : []
 
     for (const { chainName, balances: chainBalances } of safeBalances) {
       if (!Array.isArray(chainBalances)) continue
@@ -160,7 +169,7 @@ export function useMinityChainBreakdown(): ChainBreakdownItem[] {
 
     const isInitia = (item: ChainBreakdownItem) => item.chainName.toLowerCase() === "initia"
     return sortWith([descend(isInitia), descend(prop("totalBalance"))], filtered)
-  }, [balances, positions, registryMap])
+  }, [balances, positions, registryMap, chainPrices])
 
   return data
 }
@@ -209,6 +218,9 @@ export function useLiquidAssetsBalance(): number {
  */
 export function useAppchainPositionsBalance(): number {
   const { positions } = useMinityPortfolio()
+  const chains = useInitiaRegistry()
+  const priceQueries = useAllChainPriceQueries()
+  const chainPrices = useMemo(() => buildPriceMap(chains, priceQueries), [chains, priceQueries])
 
   return useMemo(() => {
     const getProtocolPositionValue = (position: ProtocolPosition): number =>
@@ -218,7 +230,9 @@ export function useAppchainPositionsBalance(): number {
     const excludedChains = ["initia", "civitia", "yominet"]
 
     let total = 0
-    const safePositions = Array.isArray(positions) ? positions : []
+    const safePositions = Array.isArray(positions)
+      ? applyFallbackPositionPricing(positions, chainPrices)
+      : []
     for (const { chainName, positions: chainPositions } of safePositions) {
       const lowerChainName = chainName.toLowerCase()
 
@@ -229,5 +243,5 @@ export function useAppchainPositionsBalance(): number {
       total += chainPositions.reduce((sum, p) => sum + getProtocolPositionValue(p), 0)
     }
     return total
-  }, [positions])
+  }, [positions, chainPrices])
 }

--- a/packages/interwovenkit-react/src/data/minity/index.ts
+++ b/packages/interwovenkit-react/src/data/minity/index.ts
@@ -48,6 +48,7 @@ export { minityQueryKeys, minityQueryOptions } from "./query-keys"
 // Utilities
 export type { StakingType } from "./utilities"
 export {
+  applyFallbackPositionPricing,
   applyFallbackPricing,
   applyLogosToGroups,
   buildAssetLogoMaps,

--- a/packages/interwovenkit-react/src/data/minity/utilities.test.ts
+++ b/packages/interwovenkit-react/src/data/minity/utilities.test.ts
@@ -5,6 +5,7 @@ import type {
   Balance,
   ChainBalanceData,
   ChainInfo,
+  ChainPositionData,
   FungiblePosition,
   PerpPosition,
   Position,
@@ -12,6 +13,7 @@ import type {
   TokenAsset,
 } from "./types"
 import {
+  applyFallbackPositionPricing,
   applyFallbackPricing,
   applyLogosToGroups,
   buildAssetLogoMaps,
@@ -921,6 +923,95 @@ describe("minity/utilities", () => {
       it("subtracts negative PnL from collateral", () => {
         expect(getPositionValue(createMockPerpPosition({ pnl: -30 }))).toBe(70)
       })
+    })
+  })
+
+  describe("applyFallbackPositionPricing", () => {
+    it("adds value to unpriced positions from the chain price map", () => {
+      const positions: ChainPositionData[] = [
+        {
+          chainId: "strat-1",
+          chainName: "strat",
+          positions: [
+            createMockProtocolPosition([
+              createMockPosition({
+                type: "staking",
+                balance: createMockBalance({
+                  symbol: "xSLP",
+                  denom: "move/xslp",
+                  formattedAmount: 2.5,
+                  value: undefined,
+                }),
+              }),
+            ]),
+          ],
+        },
+      ]
+
+      const result = applyFallbackPositionPricing(
+        positions,
+        new Map([["strat-1", new Map([["move/xslp", 1.2]])]]),
+      )
+      const priced = result[0].positions[0].positions[0]
+
+      expect(getPositionValue(priced)).toBe(3)
+    })
+
+    it("does not overwrite existing values", () => {
+      const positions: ChainPositionData[] = [
+        {
+          chainId: "strat-1",
+          chainName: "strat",
+          positions: [
+            createMockProtocolPosition([
+              createMockPosition({
+                type: "staking",
+                balance: createMockBalance({
+                  symbol: "xSLP",
+                  formattedAmount: 2.5,
+                  value: 10,
+                }),
+              }),
+            ]),
+          ],
+        },
+      ]
+
+      const result = applyFallbackPositionPricing(
+        positions,
+        new Map([["strat-1", new Map([["uinit", 1.2]])]]),
+      )
+
+      expect(getPositionValue(result[0].positions[0].positions[0])).toBe(10)
+    })
+
+    it("skips positions when the chain price map has no matching denom", () => {
+      const positions: ChainPositionData[] = [
+        {
+          chainId: "other-1",
+          chainName: "other",
+          positions: [
+            createMockProtocolPosition([
+              createMockPosition({
+                type: "staking",
+                balance: createMockBalance({
+                  symbol: "xSLP",
+                  denom: "move/xslp",
+                  formattedAmount: 2.5,
+                  value: undefined,
+                }),
+              }),
+            ]),
+          ],
+        },
+      ]
+
+      const result = applyFallbackPositionPricing(
+        positions,
+        new Map([["other-1", new Map([["uinit", 1.2]])]]),
+      )
+
+      expect(getPositionValue(result[0].positions[0].positions[0])).toBe(0)
     })
   })
 

--- a/packages/interwovenkit-react/src/data/minity/utilities.ts
+++ b/packages/interwovenkit-react/src/data/minity/utilities.ts
@@ -7,6 +7,7 @@ import type {
   Balance,
   ChainBalanceData,
   ChainInfo,
+  ChainPositionData,
   DenomGroup,
   PerpPosition,
   Position,
@@ -157,6 +158,48 @@ export function getPositionValue(position: Position): number {
     return -value
   }
   return value
+}
+
+type PositionWithPricedBalance = Position & { balance: Exclude<Balance, { type: "unknown" }> }
+
+function hasPricedBalance(position: Position): position is PositionWithPricedBalance {
+  if (position.type === "fungible-position" || position.type === "perp-position") return false
+  return position.balance.type !== "unknown"
+}
+
+export function applyFallbackPositionPricing(
+  positions: ChainPositionData[],
+  chainPrices: Map<string, Map<string, number>>,
+): ChainPositionData[] {
+  return positions.map((chainData) => {
+    const prices = chainPrices.get(chainData.chainId)
+    if (!prices) return chainData
+
+    let changedProtocol = false
+    const protocols = chainData.positions.map((protocol) => {
+      let changedPosition = false
+      const protocolPositions = protocol.positions.map((position) => {
+        if (!hasPricedBalance(position)) return position
+
+        const { balance } = position
+        if (balance.value != null && balance.value > 0) return position
+
+        const price = prices.get(balance.denom) ?? 0
+        const value = balance.formattedAmount * price
+        if (!Number.isFinite(value) || value <= 0) return position
+
+        changedPosition = true
+        return { ...position, balance: { ...balance, value } }
+      })
+
+      if (!changedPosition) return protocol
+      changedProtocol = true
+      return { ...protocol, positions: protocolPositions }
+    })
+
+    if (!changedProtocol) return chainData
+    return { ...chainData, positions: protocols }
+  })
 }
 
 /** Get section key for position - groups staking types, perp, and separates lending by direction */

--- a/packages/interwovenkit-react/src/data/strat.test.ts
+++ b/packages/interwovenkit-react/src/data/strat.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type * as InitiaUtils from "@initia/utils"
+import { createMoveClient } from "@initia/utils"
+import type { NormalizedChain, PriceItem } from "./chains"
+import type { Config } from "./config"
+import { fetchStratSupplementalPrices, parseXslpPriceInCollateral } from "./strat"
+
+vi.mock("@initia/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof InitiaUtils>()
+  return { ...actual, createMoveClient: vi.fn() }
+})
+
+describe("parseXslpPriceInCollateral", () => {
+  it("parses a decimal string view result (BigDecimal serialization)", () => {
+    expect(parseXslpPriceInCollateral("0.99424041")).toBeCloseTo(0.99424041)
+  })
+
+  it("parses a whole-number decimal string without scaling it as base units", () => {
+    // get_strat_share_to_xslp_ratio returned "1" on-chain — must stay 1, not 0.000001.
+    expect(parseXslpPriceInCollateral("1")).toBe(1)
+  })
+
+  it("parses a one-item array view result", () => {
+    expect(parseXslpPriceInCollateral(["2.5"])).toBe(2.5)
+  })
+
+  it("returns undefined for invalid or non-positive values", () => {
+    expect(parseXslpPriceInCollateral("")).toBeUndefined()
+    expect(parseXslpPriceInCollateral("0")).toBeUndefined()
+    expect(parseXslpPriceInCollateral({ value: "1000000" })).toBeUndefined()
+  })
+})
+
+describe("fetchStratSupplementalPrices", () => {
+  const stratChain = {
+    chain_name: "strat",
+    restUrl: "https://rest.strat.example.com",
+  } as NormalizedChain
+  const config: Config = {
+    stratLpModuleAddress: "0x9a838c8d805e885481f594efee110d6f5b407d530866f4973955afae88941733",
+    stratXslpCollateralMetadata:
+      "0x13bab7c0ed9dd9f4609f7dee7a5f69c99e14eca507f77e088d9b429f77e47b81",
+  } as Config
+
+  const xslpDenom = "move/4e11c0a219f362e4d0e1f131699aa83bee40ebc8701b424373a8517d0c9e85fb"
+  const basePrices: PriceItem[] = [
+    { id: "ibc/init", symbol: "INIT", price: 0.05 },
+    { id: "ibc/iusd", symbol: "iUSD", price: 0.999484 },
+    { id: xslpDenom, symbol: "xSLP", price: 0 },
+  ]
+
+  beforeEach(() => {
+    vi.mocked(createMoveClient).mockReset()
+  })
+
+  it("returns [] for non-Strat chains without calling the Move client", async () => {
+    const otherChain = {
+      chain_name: "initia",
+      restUrl: "https://rest.example.com",
+    } as NormalizedChain
+    const result = await fetchStratSupplementalPrices(otherChain, basePrices, config)
+
+    expect(result).toEqual([])
+    expect(createMoveClient).not.toHaveBeenCalled()
+  })
+
+  it("returns [] when the Strat addresses aren't configured for this network", async () => {
+    const result = await fetchStratSupplementalPrices(stratChain, basePrices, {} as Config)
+
+    expect(result).toEqual([])
+    expect(createMoveClient).not.toHaveBeenCalled()
+  })
+
+  it("returns [] when the indexer doesn't list an xSLP asset at all", async () => {
+    const pricesWithoutXslp = basePrices.filter((price) => price.symbol !== "xSLP")
+    const result = await fetchStratSupplementalPrices(stratChain, pricesWithoutXslp, config)
+
+    expect(result).toEqual([])
+    expect(createMoveClient).not.toHaveBeenCalled()
+  })
+
+  it("returns [] when the indexer already has a positive xSLP price (nothing to supplement)", async () => {
+    const pricesWithXslpPriced = basePrices.map((price) =>
+      price.symbol === "xSLP" ? { ...price, price: 1.5 } : price,
+    )
+    const result = await fetchStratSupplementalPrices(stratChain, pricesWithXslpPriced, config)
+
+    expect(result).toEqual([])
+    expect(createMoveClient).not.toHaveBeenCalled()
+  })
+
+  it("prices xSLP under its real indexer denom, converted to USD via iUSD's own price", async () => {
+    const viewFunction = vi.fn().mockResolvedValue("0.99424041")
+    vi.mocked(createMoveClient).mockReturnValue({ viewFunction })
+
+    const result = await fetchStratSupplementalPrices(stratChain, basePrices, config)
+
+    // 0.99424041 (xSLP-in-iUSD) * 0.999484 (iUSD-in-USD), not assumed 1:1.
+    expect(result).toEqual([{ id: xslpDenom, price: 0.99424041 * 0.999484 }])
+    expect(viewFunction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        moduleAddress: config.stratLpModuleAddress,
+        moduleName: "lp",
+        functionName: "get_xslp_price_in_collateral",
+        typeArgs: [],
+      }),
+    )
+    // The view function requires the collateral metadata as an argument — omitting it fails
+    // on-chain with INVALID_MAIN_FUNCTION_SIGNATURE (confirmed against strat-1 mainnet).
+    expect(viewFunction.mock.calls[0][0].args).toHaveLength(1)
+  })
+
+  it("falls back to a 1:1 collateral-to-USD rate when iUSD itself isn't in the indexer list", async () => {
+    const viewFunction = vi.fn().mockResolvedValue("0.99424041")
+    vi.mocked(createMoveClient).mockReturnValue({ viewFunction })
+    const pricesWithoutIusd = basePrices.filter((price) => price.symbol !== "iUSD")
+
+    const result = await fetchStratSupplementalPrices(stratChain, pricesWithoutIusd, config)
+
+    expect(result).toEqual([{ id: xslpDenom, price: 0.99424041 }])
+  })
+
+  it("falls back to a 1:1 rate when iUSD is present but itself unpriced (price: 0)", async () => {
+    const viewFunction = vi.fn().mockResolvedValue("0.99424041")
+    vi.mocked(createMoveClient).mockReturnValue({ viewFunction })
+    const pricesWithZeroIusd = basePrices.map((price) =>
+      price.symbol === "iUSD" ? { ...price, price: 0 } : price,
+    )
+
+    const result = await fetchStratSupplementalPrices(stratChain, pricesWithZeroIusd, config)
+
+    expect(result).toEqual([{ id: xslpDenom, price: 0.99424041 }])
+  })
+
+  it("matches xSLP/iUSD symbols case-insensitively", async () => {
+    const viewFunction = vi.fn().mockResolvedValue("0.99424041")
+    vi.mocked(createMoveClient).mockReturnValue({ viewFunction })
+    const pricesWithDifferentCasing = basePrices.map((price) => ({
+      ...price,
+      symbol: price.symbol?.toLowerCase(),
+    }))
+
+    const result = await fetchStratSupplementalPrices(stratChain, pricesWithDifferentCasing, config)
+
+    expect(result).toEqual([{ id: xslpDenom, price: 0.99424041 * 0.999484 }])
+  })
+
+  it("returns [] when the view call throws", async () => {
+    const viewFunction = vi.fn().mockRejectedValue(new Error("VM error"))
+    vi.mocked(createMoveClient).mockReturnValue({ viewFunction })
+
+    const result = await fetchStratSupplementalPrices(stratChain, basePrices, config)
+
+    expect(result).toEqual([])
+  })
+
+  it("returns [] when the view result parses to a non-positive price", async () => {
+    const viewFunction = vi.fn().mockResolvedValue("0")
+    vi.mocked(createMoveClient).mockReturnValue({ viewFunction })
+
+    const result = await fetchStratSupplementalPrices(stratChain, basePrices, config)
+
+    expect(result).toEqual([])
+  })
+})

--- a/packages/interwovenkit-react/src/data/strat.ts
+++ b/packages/interwovenkit-react/src/data/strat.ts
@@ -1,0 +1,74 @@
+import BigNumber from "bignumber.js"
+import { bcs, createMoveClient } from "@initia/utils"
+import type { NormalizedChain, PriceItem } from "./chains"
+import type { Config } from "./config"
+import { IUSD_SYMBOL, STRAT_CHAIN_NAME, XSLP_SYMBOL } from "./constants"
+
+function getScalarViewValue(result: unknown): unknown {
+  if (Array.isArray(result)) return result[0]
+  return result
+}
+
+function findBySymbol(prices: PriceItem[], symbol: string): PriceItem | undefined {
+  return prices.find((price) => price.symbol?.toUpperCase() === symbol.toUpperCase())
+}
+
+/**
+ * `get_xslp_price_in_collateral` returns a Move `BigDecimal`, serialized by the view-function REST
+ * endpoint as a plain decimal string (e.g. "0.994..."), not a scaled base-unit integer.
+ */
+export function parseXslpPriceInCollateral(result: unknown): number | undefined {
+  const value = getScalarViewValue(result)
+  if (typeof value !== "string" && typeof value !== "number") return undefined
+
+  const raw = String(value)
+  if (!raw) return undefined
+
+  const price = BigNumber(raw)
+  if (!price.isFinite() || !price.gt(0)) return undefined
+  return price.toNumber()
+}
+
+type StratConfig = Pick<Config, "stratLpModuleAddress" | "stratXslpCollateralMetadata">
+
+/**
+ * Supplements the indexer price list with xSLP's price via a Strat Move view call.
+ *
+ * The view function's argument is the vault's *collateral* metadata (e.g. iUSD), not xSLP's own —
+ * so xSLP's `id` (denom) is looked up by symbol from the indexer response instead of derived from
+ * an address. Result is converted to USD using the collateral's own indexer price, not assumed 1:1.
+ */
+export async function fetchStratSupplementalPrices(
+  { chain_name, restUrl }: NormalizedChain,
+  prices: PriceItem[],
+  {
+    stratLpModuleAddress: moduleAddress,
+    stratXslpCollateralMetadata: collateralMetadata,
+  }: StratConfig,
+): Promise<PriceItem[]> {
+  if (chain_name.toLowerCase() !== STRAT_CHAIN_NAME || !moduleAddress || !collateralMetadata)
+    return []
+
+  const xslp = findBySymbol(prices, XSLP_SYMBOL)
+  if (!xslp || xslp.price > 0) return []
+
+  try {
+    const { viewFunction } = createMoveClient(restUrl)
+    const result = await viewFunction<unknown>({
+      moduleAddress,
+      moduleName: "lp",
+      functionName: "get_xslp_price_in_collateral",
+      typeArgs: [],
+      args: [bcs.object().serialize(collateralMetadata).toBase64()],
+    })
+    const priceInCollateral = parseXslpPriceInCollateral(result)
+    if (!priceInCollateral) return []
+
+    // `0` (present but unpriced, same pattern xSLP itself uses) must also fall back to 1, not `?? 1`.
+    const collateralPrice = findBySymbol(prices, IUSD_SYMBOL)?.price
+    const collateralUsdPrice = collateralPrice && collateralPrice > 0 ? collateralPrice : 1
+    return [{ id: xslp.id, price: priceInCollateral * collateralUsdPrice }]
+  } catch {
+    return []
+  }
+}

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/Portfolio.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/Portfolio.tsx
@@ -138,6 +138,7 @@ const Portfolio = () => {
             searchQuery={searchQuery}
             selectedChain={selectedChain}
             chainInfoMap={chainInfoMap}
+            chainPrices={chainPrices}
           />
         </AsyncBoundary>
       </section>

--- a/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/Positions.tsx
+++ b/packages/interwovenkit-react/src/pages/wallet/tabs/portfolio/Positions.tsx
@@ -5,6 +5,7 @@ import Skeletons from "@/components/Skeletons"
 import Status from "@/components/Status"
 import { useLayer1 } from "@/data/chains"
 import {
+  applyFallbackPositionPricing,
   type ChainInfo,
   getPositionValue,
   type PortfolioChainPositionGroup,
@@ -19,141 +20,145 @@ export interface PositionsProps {
   searchQuery: string
   selectedChain: string
   chainInfoMap: Map<string, ChainInfo>
+  chainPrices: Map<string, Map<string, number>>
 }
 
-const Positions = memo(({ searchQuery, selectedChain, chainInfoMap }: PositionsProps) => {
-  // Position data (SSE - streams progressively)
-  const { positions, isLoading } = useMinityPortfolio()
+const Positions = memo(
+  ({ searchQuery, selectedChain, chainInfoMap, chainPrices }: PositionsProps) => {
+    // Position data (SSE - streams progressively)
+    const { positions, isLoading } = useMinityPortfolio()
 
-  // Layer 1 chain info
-  const layer1 = useLayer1()
+    // Layer 1 chain info
+    const layer1 = useLayer1()
 
-  // Filter and transform positions into chain groups
-  const filteredChainGroups = useMemo(() => {
-    const result: PortfolioChainPositionGroup[] = []
+    // Filter and transform positions into chain groups
+    const filteredChainGroups = useMemo(() => {
+      const result: PortfolioChainPositionGroup[] = []
+      const pricedPositions = applyFallbackPositionPricing(positions, chainPrices)
 
-    for (const chainData of positions) {
-      // Skip if positions is not an array
-      if (!Array.isArray(chainData.positions)) continue
+      for (const chainData of pricedPositions) {
+        // Skip if positions is not an array
+        if (!Array.isArray(chainData.positions)) continue
 
-      // Get chain info from breakdown
-      const chainInfo = chainInfoMap.get(chainData.chainName.toLowerCase())
-      const chainNameLower = chainData.chainName.toLowerCase()
-      const prettyNameLower = (chainInfo?.prettyName ?? chainData.chainName).toLowerCase()
+        // Get chain info from breakdown
+        const chainInfo = chainInfoMap.get(chainData.chainName.toLowerCase())
+        const chainNameLower = chainData.chainName.toLowerCase()
+        const prettyNameLower = (chainInfo?.prettyName ?? chainData.chainName).toLowerCase()
 
-      // Filter by selected chain (using chainId)
-      if (selectedChain && chainInfo?.chainId !== selectedChain) {
-        continue
-      }
-
-      // Check if chain has any actual renderable positions (not fungible positions)
-      const hasAnyPositions = chainData.positions.some((protocol) =>
-        protocol.positions.some((position) => position.type !== "fungible-position"),
-      )
-
-      // Skip chain if it has no displayable content
-      if (!hasAnyPositions) {
-        continue
-      }
-
-      // Skip chain if search query doesn't match raw identifier or display label
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        if (!chainNameLower.includes(query) && !prettyNameLower.includes(query)) {
+        // Filter by selected chain (using chainId)
+        if (selectedChain && chainInfo?.chainId !== selectedChain) {
           continue
         }
+
+        // Check if chain has any actual renderable positions (not fungible positions)
+        const hasAnyPositions = chainData.positions.some((protocol) =>
+          protocol.positions.some((position) => position.type !== "fungible-position"),
+        )
+
+        // Skip chain if it has no displayable content
+        if (!hasAnyPositions) {
+          continue
+        }
+
+        // Skip chain if search query doesn't match raw identifier or display label
+        if (searchQuery) {
+          const query = searchQuery.toLowerCase()
+          if (!chainNameLower.includes(query) && !prettyNameLower.includes(query)) {
+            continue
+          }
+        }
+
+        // Filter protocols by search query (match protocol name)
+        const filteredProtocols = chainData.positions.filter((protocol) => {
+          if (searchQuery && !protocol.protocol.toLowerCase().includes(searchQuery.toLowerCase())) {
+            return false
+          }
+          return Array.isArray(protocol.positions) && protocol.positions.length > 0
+        })
+
+        const isInitia = layer1.chainId === chainInfo?.chainId
+
+        // Calculate total value for this chain
+        const totalValue = filteredProtocols.reduce((sum, protocol) => {
+          return (
+            sum +
+            protocol.positions.reduce(
+              (positionSum, position) => positionSum + getPositionValue(position),
+              0,
+            )
+          )
+        }, 0)
+
+        result.push({
+          chainId: chainInfo?.chainId ?? "",
+          chainName: chainData.chainName,
+          prettyName: chainInfo?.prettyName ?? chainData.chainName,
+          chainLogo: chainInfo?.logoUrl ?? "",
+          protocols: filteredProtocols,
+          isInitia,
+          totalValue,
+        })
       }
 
-      // Filter protocols by search query (match protocol name)
-      const filteredProtocols = chainData.positions.filter((protocol) => {
-        if (searchQuery && !protocol.protocol.toLowerCase().includes(searchQuery.toLowerCase())) {
-          return false
-        }
-        return Array.isArray(protocol.positions) && protocol.positions.length > 0
-      })
+      // Chains excluded from value calculations (fungible NFTs only, no USD values)
+      const excludedChains = ["civitia", "yominet"]
 
-      const isInitia = layer1.chainId === chainInfo?.chainId
+      // Sort: Initia first, then excluded chains last, then by value descending, then alphabetically
+      return sortWith(
+        [
+          descend((group: PortfolioChainPositionGroup) => group.isInitia ?? false),
+          ascend((group: PortfolioChainPositionGroup) =>
+            excludedChains.includes(group.chainName.toLowerCase()),
+          ),
+          descend((group: PortfolioChainPositionGroup) => group.totalValue ?? 0),
+          ascend((group: PortfolioChainPositionGroup) => group.prettyName.toLowerCase()),
+        ],
+        result,
+      )
+    }, [positions, chainPrices, chainInfoMap, searchQuery, selectedChain, layer1.chainId])
 
-      // Calculate total value for this chain
-      const totalValue = filteredProtocols.reduce((sum, protocol) => {
-        return (
-          sum +
-          protocol.positions.reduce(
-            (positionSum, position) => positionSum + getPositionValue(position),
-            0,
-          )
-        )
-      }, 0)
+    const hasPositions = filteredChainGroups.length > 0
 
-      result.push({
-        chainId: chainInfo?.chainId ?? "",
-        chainName: chainData.chainName,
-        prettyName: chainInfo?.prettyName ?? chainData.chainName,
-        chainLogo: chainInfo?.logoUrl ?? "",
-        protocols: filteredProtocols,
-        isInitia,
-        totalValue,
-      })
-    }
-
-    // Chains excluded from value calculations (fungible NFTs only, no USD values)
-    const excludedChains = ["civitia", "yominet"]
-
-    // Sort: Initia first, then excluded chains last, then by value descending, then alphabetically
-    return sortWith(
-      [
-        descend((group: PortfolioChainPositionGroup) => group.isInitia ?? false),
-        ascend((group: PortfolioChainPositionGroup) =>
-          excludedChains.includes(group.chainName.toLowerCase()),
-        ),
-        descend((group: PortfolioChainPositionGroup) => group.totalValue ?? 0),
-        ascend((group: PortfolioChainPositionGroup) => group.prettyName.toLowerCase()),
-      ],
-      result,
-    )
-  }, [positions, chainInfoMap, searchQuery, selectedChain, layer1.chainId])
-
-  const hasPositions = filteredChainGroups.length > 0
-
-  return (
-    <div className={styles.container}>
-      <div className={styles.header}>
-        <span className={styles.title}>Positions</span>
-        {hasPositions && (
-          <AsyncBoundary suspenseFallback={<Skeletons height={16} width={60} length={1} />}>
-            <PositionsTotalValue filteredChainGroups={filteredChainGroups} />
-          </AsyncBoundary>
+    return (
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <span className={styles.title}>Positions</span>
+          {hasPositions && (
+            <AsyncBoundary suspenseFallback={<Skeletons height={16} width={60} length={1} />}>
+              <PositionsTotalValue filteredChainGroups={filteredChainGroups} />
+            </AsyncBoundary>
+          )}
+        </div>
+        {hasPositions ? (
+          <div className={styles.list}>
+            {filteredChainGroups.map((chainGroup) => {
+              if (chainGroup.isInitia) {
+                // For L1, render InitiaPositionGroup with on-chain staking data
+                // Wrap in AsyncBoundary for suspense queries (rewards)
+                return (
+                  <AsyncBoundary
+                    key={chainGroup.chainName}
+                    suspenseFallback={
+                      <div className={styles.skeletonWrapper}>
+                        <Skeletons height={56} length={1} />
+                      </div>
+                    }
+                  >
+                    <InitiaPositionGroup chainGroup={chainGroup} />
+                  </AsyncBoundary>
+                )
+              }
+              return <AppchainPositionGroup key={chainGroup.chainName} chainGroup={chainGroup} />
+            })}
+          </div>
+        ) : positions.length === 0 && isLoading ? (
+          <Skeletons height={56} length={3} />
+        ) : (
+          <Status>No positions</Status>
         )}
       </div>
-      {hasPositions ? (
-        <div className={styles.list}>
-          {filteredChainGroups.map((chainGroup) => {
-            if (chainGroup.isInitia) {
-              // For L1, render InitiaPositionGroup with on-chain staking data
-              // Wrap in AsyncBoundary for suspense queries (rewards)
-              return (
-                <AsyncBoundary
-                  key={chainGroup.chainName}
-                  suspenseFallback={
-                    <div className={styles.skeletonWrapper}>
-                      <Skeletons height={56} length={1} />
-                    </div>
-                  }
-                >
-                  <InitiaPositionGroup chainGroup={chainGroup} />
-                </AsyncBoundary>
-              )
-            }
-            return <AppchainPositionGroup key={chainGroup.chainName} chainGroup={chainGroup} />
-          })}
-        </div>
-      ) : positions.length === 0 && isLoading ? (
-        <Skeletons height={56} length={3} />
-      ) : (
-        <Status>No positions</Status>
-      )}
-    </div>
-  )
-})
+    )
+  },
+)
 
 export default Positions

--- a/packages/interwovenkit-react/src/public/app/Drawer.tsx
+++ b/packages/interwovenkit-react/src/public/app/Drawer.tsx
@@ -76,7 +76,7 @@ const Drawer = ({ children }: PropsWithChildren) => {
 
       return (
         <Scrollable>
-          <Status error>{error.message}</Status>
+          <Status error>{error instanceof Error ? error.message : String(error)}</Status>
           <Footer>
             <Button.White onClick={retry}>Retry</Button.White>
           </Footer>

--- a/packages/interwovenkit-react/src/public/data/constants.ts
+++ b/packages/interwovenkit-react/src/public/data/constants.ts
@@ -11,6 +11,8 @@ export const MAINNET: Config = {
   usernamesModuleAddress: "0x72ed9b26ecdcd6a21d304df50f19abfdbe31d2c02f60c84627844620a45940ef",
   lockStakeModuleAddress: "0x3a886b32a802582f2e446e74d4a24d1d7ed01adf46d2a8f65c5723887e708789",
   clammVaultModuleAddress: "0xef13fcd6485529958442e833ceffbd4fcb2c489e2715d8a4c703779ba28577b6",
+  stratLpModuleAddress: "0x9a838c8d805e885481f594efee110d6f5b407d530866f4973955afae88941733",
+  stratXslpCollateralMetadata: "0x13bab7c0ed9dd9f4609f7dee7a5f69c99e14eca507f77e088d9b429f77e47b81", // iUSD, not xSLP itself
   minityUrl: "https://portfolio-api.minity.xyz",
   dexUrl: "https://dex-api.initia.xyz",
   vipUrl: "https://vip-api.initia.xyz",
@@ -29,6 +31,8 @@ export const TESTNET: Config = {
   usernamesModuleAddress: "0x42cd8467b1c86e59bf319e5664a09b6b5840bb3fac64f5ce690b5041c530565a",
   lockStakeModuleAddress: "0x81c3ea419d2fd3a27971021d9dd3cc708def05e5d6a09d39b2f1f9ba18312264",
   clammVaultModuleAddress: "0x7b7811c87e398995937f35eb7bad9a92f7ac199f025735923e1a95f05f21215a",
+  stratLpModuleAddress: undefined,
+  stratXslpCollateralMetadata: undefined,
   minityUrl: "https://portfolio-api.minity.xyz",
   dexUrl: "https://dex-api.initiation-2.initia.xyz",
   vipUrl: "https://vip-api.testnet.initia.xyz",


### PR DESCRIPTION
- Add Strat xSLP supplemental pricing via Move view, merge it into the existing price map, and use generic Minity position fallback pricing for missing USD values.

- Adds mainnet Strat config, example-app mock helper, and fixes unknown-error rendering.

<img width="397" height="204" alt="Screenshot 2569-08-10 at 4 46 23 PM" src="https://github.com/user-attachments/assets/492d6719-2d86-4fe5-9ea3-452b32190542" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added supplemental Strat xSLP pricing for more accurate portfolio valuations.
  * Added fallback pricing for supported positions without available values.
  * Added configuration for Strat pricing and xSLP collateral metadata on mainnet and testnet.

* **Bug Fixes**
  * Improved portfolio position value calculations when direct pricing is unavailable.
  * Error messages now display safely for both standard errors and other thrown values.

* **Tests**
  * Added coverage for supplemental pricing, fallback valuations, invalid inputs, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->