### PR TITLE
feat(deposit): support onramp presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
       "prettier --write"
     ]
   },
-  "packageManager": "pnpm@11.0.8"
+  "packageManager": "pnpm@11.20.0"
 }

--- a/packages/interwovenkit-react/src/data/deposit.test.ts
+++ b/packages/interwovenkit-react/src/data/deposit.test.ts
@@ -1,0 +1,27 @@
+import type { OnrampPreset } from "@/pages/deposit/data/assetOptions"
+import { normalizeOnrampPreset } from "./deposit"
+
+describe("normalizeOnrampPreset", () => {
+  test("normalizes a valid host preset", () => {
+    expect(normalizeOnrampPreset({ amount: " 40.50 ", currency: " USD " })).toEqual({
+      amount: "40.50",
+      currency: "usd",
+    })
+  })
+
+  test.each(["", ".5", "1.", "-5", "1e3", "1,000", "1.234", "abc"])(
+    "rejects an invalid amount: %s",
+    (amount) => {
+      expect(() => normalizeOnrampPreset({ amount, currency: "USD" })).toThrow(/onramp amount/)
+    },
+  )
+
+  test("rejects an invalid currency", () => {
+    expect(() => normalizeOnrampPreset({ amount: "40", currency: "US" })).toThrow(/onramp currency/)
+  })
+
+  test("rejects non-string values at runtime", () => {
+    const onramp = { amount: 40, currency: "USD" } as unknown as OnrampPreset
+    expect(() => normalizeOnrampPreset(onramp)).toThrow(/must be strings/)
+  })
+})

--- a/packages/interwovenkit-react/src/data/deposit.ts
+++ b/packages/interwovenkit-react/src/data/deposit.ts
@@ -1,8 +1,25 @@
-import type { AssetOption } from "@/pages/deposit/data/assetOptions"
+import type { AssetOption, OnrampPreset } from "@/pages/deposit/data/assetOptions"
 import { usePrefetchDepositAssets } from "@/pages/deposit/data/assets"
 import { useAddress } from "@/public/data/hooks"
 import { useDefaultChain } from "./chains"
 import { useModal } from "./ui"
+
+export function normalizeOnrampPreset(onramp: OnrampPreset): OnrampPreset {
+  if (typeof onramp.amount !== "string" || typeof onramp.currency !== "string") {
+    throw new Error("onramp amount and currency must be strings")
+  }
+
+  const amount = onramp.amount.trim()
+  const currency = onramp.currency.trim().toLowerCase()
+  if (!/^\d+(?:\.\d{1,2})?$/.test(amount)) {
+    throw new Error("onramp amount must be a non-negative decimal with at most 2 decimal places")
+  }
+  if (!/^[a-z]{3}$/.test(currency)) {
+    throw new Error("onramp currency must be a 3-letter ISO code")
+  }
+
+  return { amount, currency }
+}
 
 export function useOpenDeposit() {
   const address = useAddress()
@@ -15,14 +32,16 @@ export function useOpenDeposit() {
     chainId?: string
     srcOptions?: AssetOption[]
     recipientAddress?: string
+    onramp?: OnrampPreset
   }) => {
     if (!address) {
       throw new Error("No wallet connected")
     }
-    const { denoms, chainId, srcOptions, recipientAddress } = params
+    const { denoms, chainId, srcOptions, recipientAddress, onramp } = params
     if (denoms.length === 0) {
       throw new Error("denoms cannot be empty")
     }
+    const normalizedOnramp = onramp ? normalizeOnrampPreset(onramp) : undefined
     // Start the Deposit API route fetch alongside the modal so the method hub
     // arrives with availability resolved (see usePrefetchDepositAssets).
     prefetchDepositAssets()
@@ -31,7 +50,12 @@ export function useOpenDeposit() {
       denom,
       chainId: targetChainId,
     }))
-    openModal("/deposit", { localOptions, remoteOptions: srcOptions, recipientAddress })
+    openModal("/deposit", {
+      localOptions,
+      remoteOptions: srcOptions,
+      recipientAddress,
+      onramp: normalizedOnramp,
+    })
   }
 }
 

--- a/packages/interwovenkit-react/src/pages/deposit/Deposit.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/Deposit.tsx
@@ -25,13 +25,17 @@ import SelectAsset from "./SelectAsset"
 import SelectDepositMethod from "./SelectDepositMethod"
 
 const Deposit = () => {
-  const { localOptions = [] } = useLocationState<DepositLocationState>()
+  const { localOptions = [], onramp } = useLocationState<DepositLocationState>()
   const form = useForm<DepositFormValues>({
     mode: "onChange",
-    defaultValues: buildDepositDefaultValues(localOptions, {
-      paymentMethodId: localStorage.getItem(LocalStorageKey.ONRAMP_PAYMENT_TYPE_ID),
-      fiatId: localStorage.getItem(LocalStorageKey.ONRAMP_FIAT_ID),
-    }),
+    defaultValues: buildDepositDefaultValues(
+      localOptions,
+      {
+        paymentMethodId: localStorage.getItem(LocalStorageKey.ONRAMP_PAYMENT_TYPE_ID),
+        fiatId: localStorage.getItem(LocalStorageKey.ONRAMP_FIAT_ID),
+      },
+      onramp,
+    ),
   })
 
   return (

--- a/packages/interwovenkit-react/src/pages/deposit/data/assetOptions.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/data/assetOptions.ts
@@ -14,6 +14,14 @@ export interface AssetOption {
   chainId: string
 }
 
+/** Initial editable values for the buy-with-cash form. */
+export interface OnrampPreset {
+  /** Non-negative fiat amount with at most two decimal places, e.g. "40". */
+  amount: string
+  /** ISO currency code, matched case-insensitively, e.g. "USD". */
+  currency: string
+}
+
 /** Location state passed by useOpenDeposit/useOpenWithdraw (data/deposit.ts). */
 export interface DepositLocationState {
   /** Receive-side (local) assets provided by the host dApp. */
@@ -23,6 +31,8 @@ export interface DepositLocationState {
   /** Host-provided recipient override; only the wallet method honors it (see
    * getTransferRecipient). */
   recipientAddress?: string
+  /** Host-provided initial values for the onramp form. */
+  onramp?: OnrampPreset
 }
 
 /**

--- a/packages/interwovenkit-react/src/pages/deposit/defaultValues.test.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/defaultValues.test.ts
@@ -11,6 +11,7 @@ describe("buildDepositDefaultValues", () => {
     expect(values.receiveChainId).toBe("")
     expect(values.receiveSymbol).toBe("")
     expect(values.trackedDepositId).toBe("")
+    expect(values.fiatAmount).toBe("")
   })
 
   test("single option: pre-selects it and skips the picker", () => {
@@ -63,5 +64,15 @@ describe("buildDepositDefaultValues", () => {
     const values = buildDepositDefaultValues([], { paymentMethodId: "banktransfer", fiatId: "eur" })
     expect(values.paymentMethodId).toBe("banktransfer")
     expect(values.fiatId).toBe("eur")
+  })
+
+  test("host onramp values override the remembered fiat and prefill the amount", () => {
+    const values = buildDepositDefaultValues(
+      [],
+      { fiatId: "eur" },
+      { amount: "40", currency: "usd" },
+    )
+    expect(values.fiatAmount).toBe("40")
+    expect(values.fiatId).toBe("usd")
   })
 })

--- a/packages/interwovenkit-react/src/pages/deposit/defaultValues.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/defaultValues.ts
@@ -1,4 +1,4 @@
-import type { AssetOption } from "./data/assetOptions"
+import type { AssetOption, OnrampPreset } from "./data/assetOptions"
 import { DEFAULT_FIAT_ID, DEFAULT_PAYMENT_TYPE_ID, type DepositFormValues } from "./context"
 
 /**
@@ -25,6 +25,7 @@ export interface PersistedOnrampDefaults {
 export function buildDepositDefaultValues(
   localOptions: AssetOption[],
   persisted: PersistedOnrampDefaults = {},
+  onramp?: OnrampPreset,
 ): DepositFormValues {
   const defaultValues: DepositFormValues = {
     page: "select-asset",
@@ -33,8 +34,8 @@ export function buildDepositDefaultValues(
     receiveChainId: "",
     method: "address",
     trackedDepositId: "",
-    fiatId: persisted.fiatId || DEFAULT_FIAT_ID,
-    fiatAmount: "",
+    fiatId: onramp?.currency || persisted.fiatId || DEFAULT_FIAT_ID,
+    fiatAmount: onramp?.amount ?? "",
     paymentMethodId: persisted.paymentMethodId || DEFAULT_PAYMENT_TYPE_ID,
     providerId: "",
   }

--- a/packages/interwovenkit-react/src/pages/deposit/onramp/OnrampFields.tsx
+++ b/packages/interwovenkit-react/src/pages/deposit/onramp/OnrampFields.tsx
@@ -10,6 +10,8 @@ import FormHelp from "@/components/form/FormHelp"
 import NumericInput from "@/components/form/NumericInput"
 import Image from "@/components/Image"
 import { LocalStorageKey } from "@/data/constants"
+import { useLocationState } from "@/lib/router"
+import type { DepositLocationState } from "../data/assetOptions"
 import { useProcessingTime, useReceiveAsset } from "../data/assets"
 import { DEFAULT_FIAT_ID, useDepositForm, useDepositNavigate } from "../context"
 import DepositSubpage from "../DepositSubpage"
@@ -79,6 +81,7 @@ function submitBlockedReason(quote: OnrampQuote): string {
  * selection opens a sub-page; submit advances to the processing screen. */
 const OnrampFields = () => {
   const { control, watch, setValue, handleSubmit } = useDepositForm()
+  const { onramp } = useLocationState<DepositLocationState>()
   const navigate = useDepositNavigate()
   const quote = useOnrampQuote()
   const onramps = useOnrampsMetadata()
@@ -122,25 +125,23 @@ const OnrampFields = () => {
     setValue("paymentMethodId", types[0].paymentTypeId)
   }, [paymentTypes.data, paymentMethodId, setValue])
 
-  // Same guard for the fiat, plus localization: converge the form's fiat on
-  // resolveFiatAnchor's pick (see its JSDoc). Convergence is unconditional
-  // because every other fiat writer agrees with the anchor (the seed is the
-  // persisted pick or the static default, and SelectFiat persists each pick), so
-  // the effect only rewrites the two automatic seeds. The result is deliberately
-  // not persisted: an automatic substitution must not overwrite the user's
-  // preference. Both lists resolve via suspense, so the effect never runs against
-  // a loading placeholder and settles on the first commit.
+  // A host preset overrides the remembered currency until SelectFiat persists
+  // the current form value. Comparing those values keeps that explicit user pick
+  // when this page remounts. Automatic substitutions remain unpersisted.
   const { fiat: supportedFiat } = useOnramperSupported()
   const recommendedFiatCode = useOnramperRecommendedFiatCode()
   useEffect(() => {
+    const persistedId = localStorage.getItem(LocalStorageKey.ONRAMP_FIAT_ID)
+    const presetCurrency = onramp?.currency && fiatId !== persistedId ? onramp.currency : null
     const anchor = resolveFiatAnchor(supportedFiat, {
-      persistedId: localStorage.getItem(LocalStorageKey.ONRAMP_FIAT_ID),
+      presetCurrency,
+      persistedId,
       recommendedCode: recommendedFiatCode,
       defaultId: DEFAULT_FIAT_ID,
     })
     if (fiatId === anchor.id) return
     setValue("fiatId", anchor.id)
-  }, [supportedFiat, recommendedFiatCode, fiatId, setValue])
+  }, [supportedFiat, recommendedFiatCode, fiatId, onramp?.currency, setValue])
 
   const quoted = quote.status === "quoted" ? quote : null
   const provider = quoted?.selected ?? null

--- a/packages/interwovenkit-react/src/pages/deposit/onramp/data/onramperLogic.test.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/onramp/data/onramperLogic.test.ts
@@ -555,13 +555,30 @@ describe("resolveFiatAnchor", () => {
   const KRW = fiat("krw", "KRW")
   const FIATS = [USD, THB, KRW]
   const candidates = (overrides: {
+    presetCurrency?: string | null
     persistedId?: string | null
     recommendedCode?: string | null
   }) => ({
+    presetCurrency: null,
     persistedId: null,
     recommendedCode: null,
     defaultId: "usd",
     ...overrides,
+  })
+
+  it("prefers a host preset over remembered and recommended currencies", () => {
+    expect(
+      resolveFiatAnchor(
+        FIATS,
+        candidates({ presetCurrency: "KRW", persistedId: "thb", recommendedCode: "USD" }),
+      ),
+    ).toBe(KRW)
+  })
+
+  it("skips an unsupported host preset in favor of the remembered currency", () => {
+    expect(
+      resolveFiatAnchor(FIATS, candidates({ presetCurrency: "XYZ", persistedId: "thb" })),
+    ).toBe(THB)
   })
 
   it("prefers the user's remembered pick over the recommendation", () => {

--- a/packages/interwovenkit-react/src/pages/deposit/onramp/data/onramperLogic.ts
+++ b/packages/interwovenkit-react/src/pages/deposit/onramp/data/onramperLogic.ts
@@ -52,6 +52,8 @@ export function matchOnramperCrypto(
 
 /** Candidate sources for the Buy form's fiat anchor, in priority order. */
 export interface FiatAnchorCandidates {
+  /** Host-provided initial currency code or id. */
+  presetCurrency: string | null
   /** The user's remembered explicit pick (localStorage), a lowercase fiat id. */
   persistedId: string | null
   /** Onramper's geolocated recommendation, an uppercase fiat CODE (e.g.
@@ -62,16 +64,16 @@ export interface FiatAnchorCandidates {
 }
 
 /**
- * The fiat the Buy form should anchor to: the user's remembered pick, else
- * Onramper's geolocated recommendation, else the default currency, else the
- * first listed fiat. Every candidate must resolve against the live supported
- * list — an unlisted value would wedge the payment-types and quotes queries
- * with no automatic recovery. Non-empty input (assertOnramperSupported)
+ * The fiat the Buy form should anchor to: the host preset, the user's remembered
+ * pick, Onramper's geolocated recommendation, the default currency, or the first
+ * listed fiat, in that order. Every candidate must resolve against the live
+ * supported list — an unlisted value would wedge the payment-types and quotes
+ * queries with no automatic recovery. Non-empty input (assertOnramperSupported)
  * guarantees a result.
  */
 export function resolveFiatAnchor(
   supportedFiat: OnramperFiat[],
-  { persistedId, recommendedCode, defaultId }: FiatAnchorCandidates,
+  { presetCurrency, persistedId, recommendedCode, defaultId }: FiatAnchorCandidates,
 ): OnramperFiat {
   const byId = (id: string | null) =>
     id ? supportedFiat.find((entry) => entry.id === id) : undefined
@@ -86,7 +88,13 @@ export function resolveFiatAnchor(
       supportedFiat.find((entry) => entry.id === lower)
     )
   }
-  return byId(persistedId) ?? byCode(recommendedCode) ?? byId(defaultId) ?? supportedFiat[0]
+  return (
+    byCode(presetCurrency) ??
+    byId(persistedId) ??
+    byCode(recommendedCode) ??
+    byId(defaultId) ??
+    supportedFiat[0]
+  )
 }
 
 const APPLE_PAY_PAYMENT_TYPE_ID = "applepay"


### PR DESCRIPTION
## Purpose

Let host dApps preset the initial amount and currency of the buy-with-cash form through `useOpenDeposit`.

## Changes

- Add an optional `onramp` param (`{ amount, currency }`) to `useOpenDeposit`, validated once at the boundary by `normalizeOnrampPreset`: values are trimmed, the currency is lowercased, the amount must be a non-negative decimal with at most two decimal places, and the currency must be a 3-letter ISO code.
- Pass the validated preset through location state into the form default values: prefill the fiat amount and select the preset currency instead of the remembered one.
- Give `presetCurrency` top priority in `resolveFiatAnchor`. When it is not in the supported list, the existing order still applies (remembered pick, recommendation, default, first entry).
- Apply the preset in `OnrampFields` only while the form value differs from the persisted one, so a currency the user picked in `SelectFiat` survives a remount. Automatic substitutions stay unpersisted.
- Bump `packageManager` from `pnpm@11.0.8` to `pnpm@11.20.0`.

## Validation

- `pnpm typecheck` passes.
- `pnpm test` passes (70 files, 797 tests).
- `pnpm lint` passes.
- Not verified in a browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bb64f3c9d73e11e4a1776d1793da861ecda8fdf1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for host-provided onramp presets when opening the deposit flow.
  - Deposit forms can now be prefilled with an initial fiat amount and currency.
  - Supported preset currencies take priority over saved selections while retaining sensible fallback behavior.

- **Bug Fixes**
  - Added validation and normalization for onramp amounts and currencies.
  - Invalid or unsupported preset values are safely rejected or ignored without disrupting deposit defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->